### PR TITLE
feat: live-browser connect mode (v0.3.15)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eoka"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 license = "MIT"
 description = "Stealth browser automation for Rust. Puppeteer/Playwright alternative with anti-bot bypass."
@@ -60,3 +60,7 @@ path = "examples/request_capture.rs"
 [[example]]
 name = "smoke"
 path = "examples/smoke.rs"
+
+[[example]]
+name = "connect_existing"
+path = "examples/connect_existing.rs"

--- a/examples/connect_existing.rs
+++ b/examples/connect_existing.rs
@@ -1,0 +1,48 @@
+//! Attach to a Chrome that's already running with `--remote-debugging-port=9222`.
+//!
+//! ```bash
+//! google-chrome --remote-debugging-port=9222 &
+//! cargo run --example connect_existing
+//! ```
+//!
+//! Lists open tabs, attaches to the first one, and saves a screenshot.
+
+use eoka::cdp::discover;
+use eoka::Browser;
+
+#[tokio::main]
+async fn main() -> eoka::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let port: u16 = std::env::args()
+        .nth(1)
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(9222);
+
+    println!("Discovering Chrome on 127.0.0.1:{}...", port);
+    let pages = discover::discover_pages("127.0.0.1", port)?;
+    let tabs: Vec<_> = pages.iter().filter(|p| p.kind == "page").collect();
+    println!("Found {} tab(s):", tabs.len());
+    for (i, t) in tabs.iter().enumerate() {
+        println!("  {}: {} — {}", i, t.title, t.url);
+    }
+
+    let first = tabs
+        .first()
+        .ok_or_else(|| eoka::Error::CdpSimple("No open page tabs".into()))?;
+
+    let browser = Browser::connect_port(port).await?;
+    let page = browser.attach_page(&first.id).await?;
+
+    println!("URL:   {}", page.url().await?);
+    println!("Title: {}", page.title().await?);
+
+    let png = page.screenshot().await?;
+    std::fs::write("connected.png", png)?;
+    println!("Wrote connected.png ({} bytes)", std::fs::metadata("connected.png")?.len());
+
+    // Note: we do NOT call browser.close() — that would send a Browser.close
+    // command to the user's real Chrome and kill it. Just drop the handle.
+    Ok(())
+}

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -171,23 +171,33 @@ impl Browser {
     }
 
     /// Connect to an existing Chrome instance at the given WebSocket CDP URL.
-    /// Obtain the URL from `curl http://localhost:9222/json/version`.
-    /// Does not patch the binary or manage the Chrome process.
-    /// Evasion scripts are still injected into new pages.
-    /// Uses default StealthConfig — use `connect_with_config()` to customize.
+    /// Obtain the URL from `curl http://localhost:9222/json/version` or use
+    /// `Browser::connect_port` for HTTP discovery.
+    ///
+    /// Defaults to `StealthConfig::live()` so attaching to a user's real browser
+    /// leaves their tabs untouched (no evasion script injection, full CDP access).
     pub async fn connect(ws_url: &str) -> Result<Self> {
-        Self::connect_with_config(ws_url, StealthConfig::default()).await
+        Self::connect_with_config(ws_url, StealthConfig::live()).await
     }
 
     /// Connect to an existing Chrome instance with a custom config.
     /// Allows customizing CDP timeout, evasion scripts, proxy auth, etc.
     pub async fn connect_with_config(ws_url: &str, config: StealthConfig) -> Result<Self> {
         let config = Arc::new(config);
-        let transport = crate::cdp::transport::Transport::connect(ws_url, config.cdp_timeout)?;
+        let transport = crate::cdp::transport::Transport::connect_with_options(
+            ws_url,
+            config.cdp_timeout,
+            config.filter_cdp,
+        )?;
         let connection = Connection::new(transport);
         let version = connection.version().await?;
         tracing::info!("Connected to Chrome: {}", version.product);
-        let evasion_script = build_evasion_script(&config);
+        // Skip building the evasion script when we won't inject it.
+        let evasion_script = if config.live_session {
+            String::new()
+        } else {
+            build_evasion_script(&config)
+        };
         Ok(Self {
             connection,
             config,
@@ -197,8 +207,23 @@ impl Browser {
         })
     }
 
+    /// Discover the DevTools URL on `127.0.0.1:<port>` and connect.
+    /// Equivalent to `curl http://127.0.0.1:<port>/json/version` then `Browser::connect`.
+    pub async fn connect_port(port: u16) -> Result<Self> {
+        let ws_url = crate::cdp::discover::discover_browser_ws("127.0.0.1", port)?;
+        Self::connect(&ws_url).await
+    }
+
+    /// `connect_port` with a custom config.
+    pub async fn connect_port_with_config(port: u16, config: StealthConfig) -> Result<Self> {
+        let ws_url = crate::cdp::discover::discover_browser_ws("127.0.0.1", port)?;
+        Self::connect_with_config(&ws_url, config).await
+    }
+
     /// Set up a session with evasion scripts and proxy auth.
     /// Common logic shared by new_page, new_blank_page, and attach_page.
+    /// In live-session mode, skips the evasion-script injection so we don't
+    /// pollute the user's tab with extra `addScriptToEvaluateOnNewDocument`.
     async fn setup_session(&self, session: &crate::cdp::Session) -> Result<()> {
         session.page_enable().await?;
 
@@ -206,9 +231,11 @@ impl Browser {
             session.fetch_enable(true).await?;
         }
 
-        session
-            .add_script_to_evaluate_on_new_document(&self.evasion_script)
-            .await?;
+        if !self.config.live_session {
+            session
+                .add_script_to_evaluate_on_new_document(&self.evasion_script)
+                .await?;
+        }
 
         Ok(())
     }
@@ -287,11 +314,17 @@ impl Browser {
         Ok(())
     }
 
-    /// Close the browser
+    /// Close the browser. In live-session mode, this is equivalent to
+    /// `disconnect()` — we never send `Browser.close` to a Chrome we don't own.
     pub async fn close(self) -> Result<()> {
-        self.connection.close().await?;
+        if self.config.live_session {
+            // Don't kill the user's Chrome; just drop the connection.
+            self.connection.transport().close().await?;
+        } else {
+            self.connection.close().await?;
+        }
 
-        // Clean up user data directory
+        // Clean up user data directory (None when connecting)
         if let Some(ref dir) = self.user_data_dir {
             let _ = std::fs::remove_dir_all(dir);
         }
@@ -302,6 +335,12 @@ impl Browser {
         }
 
         Ok(())
+    }
+
+    /// Drop the WebSocket without sending `Browser.close`. Use this when
+    /// connected to a user-owned browser to disconnect without killing it.
+    pub async fn disconnect(self) -> Result<()> {
+        self.connection.transport().close().await
     }
 }
 

--- a/src/cdp/discover.rs
+++ b/src/cdp/discover.rs
@@ -1,0 +1,101 @@
+//! HTTP discovery for Chrome's DevTools endpoint.
+//!
+//! Chrome started with `--remote-debugging-port=N` exposes a small HTTP API:
+//! - `GET /json/version` — browser-level info, including `webSocketDebuggerUrl`
+//! - `GET /json` — list of page targets, each with its own `webSocketDebuggerUrl`
+//!
+//! Chrome rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` as
+//! anti-DNS-rebinding. We always send `Host: localhost` to stay compatible.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::error::{Error, Result};
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One entry from `GET /json` — a single browsing target (tab, iframe, worker).
+#[derive(Debug, Clone, Deserialize)]
+pub struct PageTarget {
+    pub id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(rename = "type", default)]
+    pub kind: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(rename = "webSocketDebuggerUrl", default)]
+    pub web_socket_debugger_url: String,
+}
+
+/// Resolve the browser-level DevTools WebSocket URL for a running Chrome.
+///
+/// ```no_run
+/// let url = eoka::cdp::discover::discover_browser_ws("127.0.0.1", 9222)?;
+/// # Ok::<(), eoka::Error>(())
+/// ```
+pub fn discover_browser_ws(host: &str, port: u16) -> Result<String> {
+    let body = http_get(host, port, "/json/version")?;
+    let value: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| Error::transport(format!("Invalid JSON from /json/version: {}", e)))?;
+    value
+        .get("webSocketDebuggerUrl")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| Error::transport("No webSocketDebuggerUrl in /json/version"))
+}
+
+/// List all current targets (tabs, workers, iframes) for a running Chrome.
+pub fn discover_pages(host: &str, port: u16) -> Result<Vec<PageTarget>> {
+    let body = http_get(host, port, "/json")?;
+    serde_json::from_str(&body)
+        .map_err(|e| Error::transport(format!("Invalid JSON from /json: {}", e)))
+}
+
+/// Probe `start..=end` on `127.0.0.1` and return the first port whose Chrome
+/// answers `/json/version`, alongside its WebSocket URL.
+pub fn auto_connect(start: u16, end: u16) -> Option<(u16, String)> {
+    (start..=end).find_map(|port| discover_browser_ws("127.0.0.1", port).ok().map(|u| (port, u)))
+}
+
+/// Minimal blocking HTTP/1.1 GET. Reads until the server closes the connection.
+fn http_get(host: &str, port: u16, path: &str) -> Result<String> {
+    let addr = format!("{}:{}", host, port);
+    let mut stream = TcpStream::connect(&addr)
+        .map_err(|e| Error::transport_io(format!("Failed to connect to {}", addr), e))?;
+    stream
+        .set_read_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|e| Error::transport_io("set_read_timeout", e))?;
+    stream
+        .set_write_timeout(Some(HTTP_TIMEOUT))
+        .map_err(|e| Error::transport_io("set_write_timeout", e))?;
+
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: localhost\r\nAccept: application/json\r\nConnection: close\r\n\r\n",
+        path
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| Error::transport_io("HTTP write", e))?;
+
+    let mut buf = Vec::with_capacity(4096);
+    stream
+        .read_to_end(&mut buf)
+        .map_err(|e| Error::transport_io("HTTP read", e))?;
+
+    let raw = String::from_utf8_lossy(&buf);
+    let header_end = raw
+        .find("\r\n\r\n")
+        .ok_or_else(|| Error::transport("Malformed HTTP response from Chrome"))?;
+    let status_line = raw.lines().next().unwrap_or("");
+    if !(status_line.starts_with("HTTP/1.1 200") || status_line.starts_with("HTTP/1.0 200")) {
+        return Err(Error::transport(format!(
+            "HTTP {} from Chrome at {}: {}",
+            path, addr, status_line
+        )));
+    }
+    Ok(raw[header_end + 4..].to_string())
+}

--- a/src/cdp/mod.rs
+++ b/src/cdp/mod.rs
@@ -5,14 +5,16 @@
 //!
 //! ## Stealth Features
 //!
-//! - Blocks detectable commands like `Runtime.enable`
+//! - Blocks detectable commands like `Runtime.enable` (toggle via `Transport::connect_with_options`)
 //! - Warns on risky commands like `Emulation.setUserAgentOverride`
-//! - Uses pipe transport (less detectable than WebSocket)
+//! - Uses a single WebSocket transport over TCP
 
 pub mod connection;
+pub mod discover;
 pub mod transport;
 pub mod types;
 
 pub use connection::{Connection, Session};
+pub use discover::{auto_connect, discover_browser_ws, discover_pages, PageTarget};
 pub use transport::Transport;
 pub use types::*;

--- a/src/cdp/transport.rs
+++ b/src/cdp/transport.rs
@@ -182,6 +182,10 @@ pub struct Transport {
     cmd_timeout: std::time::Duration,
     /// Reader thread handle — checked for panics before sending commands
     reader_handle: Option<std::thread::JoinHandle<()>>,
+    /// When true, drop "detectable" commands (`Runtime.enable`, etc.) silently.
+    /// Defaults to true. Disable when you own the browser session and need
+    /// full DevTools-equivalent control.
+    filter_cdp: bool,
 }
 
 /// A parsed CDP message (response or event)
@@ -284,6 +288,7 @@ impl Transport {
         stream: TcpStream,
         proxy_auth: Option<(String, String)>,
         cdp_timeout_secs: u64,
+        filter_cdp: bool,
     ) -> Result<Self> {
         let cmd_timeout = std::time::Duration::from_secs(cdp_timeout_secs);
         tracing::debug!("CDP timeout set to {}s", cdp_timeout_secs);
@@ -319,6 +324,7 @@ impl Transport {
             event_rx: Mutex::new(event_rx),
             cmd_timeout,
             reader_handle: Some(reader_handle),
+            filter_cdp,
         })
     }
 
@@ -330,14 +336,26 @@ impl Transport {
         cdp_timeout_secs: u64,
     ) -> Result<Self> {
         let stream = Self::ws_handshake(ws_url)?;
-        Self::build(Some(child), stream, proxy_auth, cdp_timeout_secs)
+        Self::build(Some(child), stream, proxy_auth, cdp_timeout_secs, true)
     }
 
     /// Connect to an existing Chrome instance at the given WebSocket URL.
     /// Does not manage a Chrome process — caller owns the browser lifecycle.
     pub fn connect(ws_url: &str, cdp_timeout_secs: u64) -> Result<Self> {
         let stream = Self::ws_handshake(ws_url)?;
-        Self::build(None, stream, None, cdp_timeout_secs)
+        Self::build(None, stream, None, cdp_timeout_secs, true)
+    }
+
+    /// Connect to an existing Chrome with full options control. Use
+    /// `filter_cdp = false` to allow `Runtime.enable` and friends — needed
+    /// when driving a user-owned browser where stealth filtering is unwanted.
+    pub fn connect_with_options(
+        ws_url: &str,
+        cdp_timeout_secs: u64,
+        filter_cdp: bool,
+    ) -> Result<Self> {
+        let stream = Self::ws_handshake(ws_url)?;
+        Self::build(None, stream, None, cdp_timeout_secs, filter_cdp)
     }
 
     /// Reader loop - runs in a separate thread to read from WebSocket.
@@ -543,7 +561,7 @@ impl Transport {
         R: DeserializeOwned,
     {
         // STEALTH: Block detectable commands - return empty object (deserializes via #[serde(default)])
-        if is_blocked(method) {
+        if self.filter_cdp && is_blocked(method) {
             tracing::debug!("Blocked CDP command: {}", method);
             return serde_json::from_value(json!({})).map_err(Into::into);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,13 @@ pub struct StealthConfig {
     /// Extra Chrome command-line arguments appended after standard stealth args.
     /// E.g. vec!["--use-fake-ui-for-media-stream".into()] to auto-grant camera.
     pub extra_args: Vec<String>,
+    /// Treat this as a session attached to a user-owned browser. When true,
+    /// `Browser::new_page`/`new_blank_page`/`attach_page` skip injecting the
+    /// evasion script. Defaults to false (set automatically by `Browser::connect*`).
+    pub live_session: bool,
+    /// Drop "detectable" CDP commands like `Runtime.enable` silently.
+    /// Defaults to true. Set to false in connect mode to get full DevTools-like control.
+    pub filter_cdp: bool,
 }
 
 impl Default for StealthConfig {
@@ -155,6 +162,8 @@ impl Default for StealthConfig {
             cdp_timeout: 30,
             timezone: None, // Random from common timezones
             extra_args: Vec::new(),
+            live_session: false,
+            filter_cdp: true,
         }
     }
 }
@@ -187,6 +196,27 @@ impl StealthConfig {
         Self {
             headless: false,
             debug: true,
+            ..Default::default()
+        }
+    }
+
+    /// Config tuned for attaching to a user-owned browser via `Browser::connect*`.
+    ///
+    /// Disables anything that touches the user's Chrome state:
+    /// - `live_session` — no evasion script injection on attached tabs
+    /// - `filter_cdp = false` — full DevTools-equivalent CDP access
+    /// - `patch_binary = false` — we don't manage the binary
+    /// - all spoofing off — the user's browser already has its own fingerprint
+    pub fn live() -> Self {
+        Self {
+            live_session: true,
+            filter_cdp: false,
+            patch_binary: false,
+            webgl_spoof: false,
+            canvas_spoof: false,
+            audio_spoof: false,
+            human_mouse: true,
+            human_typing: true,
             ..Default::default()
         }
     }


### PR DESCRIPTION
## Summary

Lets eoka attach to a Chrome the user is actively using (started with `--remote-debugging-port=N`) without polluting their tabs.

- **`src/cdp/discover.rs`** — `GET /json/version` and `/json` over plain TCP, plus `auto_connect()` port scan. Sends `Host: localhost` to satisfy Chrome's anti-DNS-rebinding check.
- **`StealthConfig::live_session`** — skip evasion-script injection on attached tabs (still does `Page.enable` for events).
- **`StealthConfig::filter_cdp`** — toggles transport's `is_blocked` filter so `Runtime.enable` et al. work when the user owns the browser.
- **`StealthConfig::live()`** — preset for connect mode (live_session + no filtering + no patching + no spoofing).
- **`Browser::connect_port` / `connect_port_with_config`** — HTTP-discover the WS URL then connect.
- **`Browser::disconnect()`** and live-mode-aware **`close()`** — never sends `Browser.close` to a Chrome we don't own.
- **`examples/connect_existing.rs`** — list tabs and screenshot the first one.
- Fixes stale "uses pipe transport" doc comment.

Bumps to **0.3.15**.

## Test plan

- [x] `cargo check --examples` clean
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 22 ignored (require Chrome), 3 doctests pass
- [ ] Live test: start `google-chrome --remote-debugging-port=9222`, run `cargo run --example connect_existing` (deferred — no Chrome in dev sandbox)

## Dependant

eoka-tools branch `claude/explore-cdp-chrome-control-IsWGZ` consumes 0.3.15 for the CLI surface (`--cdp`, `clone-from`, `--from-profile`).

https://claude.ai/code/session_01XxZWTMkamuAKw5cVZr9549

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxZWTMkamuAKw5cVZr9549)_