### PR TITLE
0.5.0: async CDP transport, owned elements, launch helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-07-06
+
+A refactor release: smaller, more reusable public API and a modern async
+transport. See the migration notes below.
+
+### Changed
+
+#### Breaking
+
+- **`Element` is now owned, not borrowed.** `Element<'a>` → `Element`; it holds a
+  cheap clone of its `Page`, so elements are `Send + 'static` — you can store
+  them, return them, and use them across `.await`/navigation. `Page` and
+  `Session` gained `Clone`.
+- **CDP internals are no longer public API.** The ~90 hand-written `cdp::types`
+  structs and the typed `Session`/`Connection` methods are now `pub(crate)`, so
+  adding a CDP field is no longer a breaking change. The deliberate low-level
+  escape hatch remains public: `Session::{session_id, target_id, transport,
+  send}`, `Connection::transport`, `Transport`, and `cdp::discover::*`.
+- **Cookies use the domain `SessionCookie`.** `Page::cookies() ->
+  Vec<SessionCookie>`, `Page::set_cookies_bulk(Vec<SessionCookie>)`, and
+  `BrowserSession::new(Vec<SessionCookie>)` (previously exposed the internal cdp
+  `Cookie`/`NetworkSetCookie`).
+- **Transport constructors are `async`** (`Transport::new`/`new_with_options`/
+  `connect`/`connect_with_options`) — the WebSocket connect is awaited.
+- **`Error` changes:** `Error::CdpSimple(String)` removed; `Error::Cdp` now has
+  `method: Option<String>` and `code: Option<i64>` (use `Error::cdp(...)` or the
+  new `Error::cdp_msg(...)`). `Error` is `#[non_exhaustive]` — match with a `_`
+  arm. `Error` now implements `Clone`.
+- Removed the unused `full_evasion_script` public function.
+
+#### Transport rewrite
+
+- The hand-rolled RFC-6455 WebSocket layer was replaced with
+  `tokio-tungstenite` (no TLS); the blocking `std::thread` reader is now an
+  async task. Events moved from a lossy 256-slot `mpsc` to a multi-consumer
+  `tokio::sync::broadcast` (new `Transport::subscribe()`); `recv_event` no
+  longer silently drops events. `transport.rs` shrank 843 → 597 lines.
+  New deps: `tokio-tungstenite`, `futures-util` (tokio `net`/`io-util`/`rt`).
+
+### Fixed
+
+- **`find_chrome` now locates non-stable Chrome channels** (Beta/Dev): it
+  resolves the real ELF sibling of a channel wrapper script, instead of only
+  hardcoding the stable `/opt/google/chrome` path.
+- `find_by_text`/`find_all_by_text` prime `DOM.getDocument` before
+  `DOM.requestNode` (previously returned 0 on an unpopulated node-id space).
+
+### Internal
+
+- Split `page.rs` (1815 lines) into `page.rs` + `element.rs` + `keyboard.rs`.
+- Every public item is now documented (`#![deny(missing_docs)]`).
+
 ## [0.4.0] - 2026-07-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ src/
 
 ### Browser
 - `Browser::launch()` / `Browser::launch_with_config(config)`
+- `Browser::launch_visible()` / `Browser::launch_debug()` - Common presets without manual config
+- `Browser::launch_with(|config| { ... })` - Inline tweaks to default stealth config
 - `browser.new_page(url)` - Create page and navigate
 - `browser.tabs()` - List all open tabs (returns `Vec<TabInfo>`)
 - `browser.activate_tab(id)` - Focus a tab

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eoka"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,13 @@ authors = ["cbxss"]
 exclude = ["/.github", "*.png", "*.jpg", "*.jpeg"]
 
 [dependencies]
-# Async runtime (minimal features — no net/io-util/macros/rt-multi-thread)
-tokio = { version = "1", features = ["process", "sync", "time"] }
+# Async runtime (minimal features — net/io-util/rt needed for the async
+# tokio-tungstenite reader task; no macros/rt-multi-thread)
+tokio = { version = "1", features = ["process", "sync", "time", "net", "io-util", "rt"] }
+
+# WebSocket transport (no TLS — CDP is always ws:// localhost)
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -186,6 +186,25 @@ browser.activate_tab(page1.target_id()).await?;
 browser.close_tab(page2.target_id()).await?;
 ```
 
+### Connect to an existing Chrome
+
+Attach to a browser you already launched with `--remote-debugging-port` instead of
+spawning one. Defaults to `StealthConfig::live()`, so the user's tabs are left
+untouched (no evasion injection).
+
+```rust
+// Start Chrome yourself: chrome --remote-debugging-port=9222
+let browser = Browser::connect_port(9222).await?;           // HTTP discovery
+// or, with the ws:// URL from http://localhost:9222/json/version:
+let browser = Browser::connect("ws://127.0.0.1:9222/devtools/browser/...").await?;
+
+for tab in browser.tabs().await? {
+    println!("{} — {}", tab.title, tab.url);
+}
+let page = browser.attach_page(&target_id).await?;
+browser.disconnect().await?;                                // leaves Chrome running
+```
+
 ### Navigation
 
 ```rust
@@ -254,7 +273,7 @@ Patches Chrome binary, injects 15 evasion scripts, blocks detectable CDP command
 
 ## How it Works
 
-~5K lines of Rust. No chromiumoxide, no puppeteer-extra. Hand-written CDP types for the ~30 commands actually needed. 9 crate dependencies.
+~9K lines of Rust (about 1.3K of that is tests). No chromiumoxide, no puppeteer-extra. Hand-written CDP types for the ~30 commands actually needed. Minimal dependency graph.
 
 ```
 src/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Chrome or Chromium installed. eoka launches and controls it via CDP.
 
 ```toml
 [dependencies]
-eoka = "0.4"
+eoka = "0.5"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ async fn main() -> Result<()> {
 ## Login Flow Example
 
 ```rust
-use eoka::{Browser, Result, StealthConfig};
+use eoka::{Browser, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let browser = Browser::launch_with_config(StealthConfig::visible()).await?;
+    let browser = Browser::launch().await?;
     let page = browser.new_page("https://example.com/login").await?;
 
     page.try_click_by_text("Accept Cookies").await?;
@@ -68,6 +68,11 @@ async fn main() -> Result<()> {
 
 ```rust
 let browser = Browser::launch().await?;
+let browser = Browser::launch_visible().await?;
+let browser = Browser::launch_debug().await?;
+let browser = Browser::launch_with(|config| {
+    config.proxy = Some("http://127.0.0.1:8080".into());
+}).await?;
 let browser = Browser::launch_with_config(config).await?;
 let page = browser.new_page("https://example.com").await?;
 let tabs = browser.tabs().await?;
@@ -249,6 +254,22 @@ page.with_retry(3, 500, || async {
 
 ## Config
 
+Most code does not need to construct a config. `Browser::launch()` starts with
+stealth defaults in headless mode. `Browser::launch_visible()` and
+`Browser::launch_debug()` are explicit opt-ins for local workflows that need a
+window.
+
+For small tweaks, mutate the default config inline:
+
+```rust
+let browser = Browser::launch_with(|config| {
+    config.headless = false;
+    config.proxy = Some("http://127.0.0.1:8080".into());
+}).await?;
+```
+
+For reusable presets or advanced setup, build a `StealthConfig` directly:
+
 ```rust
 let config = StealthConfig {
     headless: false,
@@ -259,7 +280,9 @@ let config = StealthConfig {
     ..Default::default()
 };
 
-// Presets
+let browser = Browser::launch_with_config(config).await?;
+
+// Presets for advanced config composition
 StealthConfig::visible()   // headless: false
 StealthConfig::debug()     // headless: false, debug: true
 ```

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,8 +1,9 @@
 //! Basic usage example for eoka
 //!
 //! Run with: cargo run --example basic
+//! Or visible: cargo run --example basic -- --visible
 
-use eoka::{Browser, Result, StealthConfig};
+use eoka::{Browser, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -11,14 +12,15 @@ async fn main() -> Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    // Launch browser with visible window for demo
-    let config = StealthConfig {
-        headless: false, // Show the browser
-        ..Default::default()
-    };
+    let visible = std::env::args().any(|a| a == "--visible");
 
+    println!("Mode: {}", if visible { "visible" } else { "headless" });
     println!("Launching browser...");
-    let browser = Browser::launch_with_config(config).await?;
+    let browser = if visible {
+        Browser::launch_visible().await?
+    } else {
+        Browser::launch().await?
+    };
 
     // Get browser version
     let version = browser.version().await?;

--- a/examples/bestbuy_cart.rs
+++ b/examples/bestbuy_cart.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example bestbuy_cart
 //! Or visible: cargo run --example bestbuy_cart -- --visible
 
-use eoka::{Browser, Result, StealthConfig};
+use eoka::{Browser, Result};
 
 const PRODUCT_URL: &str = "https://www.bestbuy.com/product/steelseries-apex-3-full-size-wired-membrane-whisper-quiet-switch-gaming-keyboard-with-10-zone-rgb-backlighting-black/J3LG47VT9S";
 
@@ -18,17 +18,16 @@ async fn main() -> Result<()> {
 
     let visible = std::env::args().any(|a| a == "--visible");
 
-    let config = StealthConfig {
-        headless: !visible,
-        ..Default::default()
-    };
-
     println!("=== Best Buy Add to Cart ===\n");
     println!("Mode: {}", if visible { "visible" } else { "headless" });
     println!("Product URL: {}\n", PRODUCT_URL);
 
     println!("Launching browser...");
-    let browser = Browser::launch_with_config(config).await?;
+    let browser = if visible {
+        Browser::launch_visible().await?
+    } else {
+        Browser::launch().await?
+    };
 
     let page = browser.new_page(PRODUCT_URL).await?;
 

--- a/examples/connect_existing.rs
+++ b/examples/connect_existing.rs
@@ -30,7 +30,7 @@ async fn main() -> eoka::Result<()> {
 
     let first = tabs
         .first()
-        .ok_or_else(|| eoka::Error::CdpSimple("No open page tabs".into()))?;
+        .ok_or_else(|| eoka::Error::cdp_msg("No open page tabs"))?;
 
     let browser = Browser::connect_port(port).await?;
     let page = browser.attach_page(&first.id).await?;

--- a/examples/detection_test.rs
+++ b/examples/detection_test.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example detection_test
 //! Or visible: cargo run --example detection_test -- --visible
 
-use eoka::{Browser, Result, StealthConfig};
+use eoka::{Browser, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -18,17 +18,16 @@ async fn main() -> Result<()> {
     // Check for --visible flag
     let visible = std::env::args().any(|a| a == "--visible");
 
-    let config = StealthConfig {
-        headless: !visible,
-        ..Default::default()
-    };
-
     println!("=== Eoka Detection Test ===\n");
     println!("Mode: {}", if visible { "visible" } else { "headless" });
     println!();
 
     println!("Launching browser...");
-    let browser = Browser::launch_with_config(config).await?;
+    let browser = if visible {
+        Browser::launch_visible().await?
+    } else {
+        Browser::launch().await?
+    };
 
     // Test 1: bot.sannysoft.com
     println!("\n--- Test 1: bot.sannysoft.com ---\n");

--- a/examples/rebrowser_test.rs
+++ b/examples/rebrowser_test.rs
@@ -3,7 +3,7 @@
 //! Run with: cargo run --example rebrowser_test
 //! Or visible: cargo run --example rebrowser_test -- --visible
 
-use eoka::{Browser, Result, StealthConfig};
+use eoka::{Browser, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,16 +16,15 @@ async fn main() -> Result<()> {
 
     let visible = std::env::args().any(|a| a == "--visible");
 
-    let config = StealthConfig {
-        headless: !visible,
-        ..Default::default()
-    };
-
     println!("=== Rebrowser Bot Detector Test ===\n");
     println!("Mode: {}", if visible { "visible" } else { "headless" });
 
     println!("\nLaunching browser...");
-    let browser = Browser::launch_with_config(config).await?;
+    let browser = if visible {
+        Browser::launch_visible().await?
+    } else {
+        Browser::launch().await?
+    };
 
     let page = browser
         .new_page("https://bot-detector.rebrowser.net/")

--- a/examples/request_capture.rs
+++ b/examples/request_capture.rs
@@ -2,7 +2,7 @@
 //!
 //! Run with: cargo run --example request_capture
 
-use eoka::{Browser, Result, StealthConfig};
+use eoka::{Browser, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,13 +16,8 @@ async fn main() -> Result<()> {
 
     println!("=== Eoka Request Capture Example ===\n");
 
-    let config = StealthConfig {
-        headless: true,
-        ..Default::default()
-    };
-
     println!("Launching browser...");
-    let browser = Browser::launch_with_config(config).await?;
+    let browser = Browser::launch().await?;
 
     // Create page
     let page = browser.new_page("about:blank").await?;

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -137,6 +137,26 @@ impl Browser {
         Self::launch_with_config(StealthConfig::default()).await
     }
 
+    /// Launch a new stealth browser with a visible window.
+    pub async fn launch_visible() -> Result<Self> {
+        Self::launch_with_config(StealthConfig::visible()).await
+    }
+
+    /// Launch a new visible stealth browser with debug logging behavior enabled.
+    pub async fn launch_debug() -> Result<Self> {
+        Self::launch_with_config(StealthConfig::debug()).await
+    }
+
+    /// Launch with the default stealth config after applying inline changes.
+    ///
+    /// This avoids constructing a full [`StealthConfig`] when only one or two
+    /// options need to change.
+    pub async fn launch_with(configure: impl FnOnce(&mut StealthConfig)) -> Result<Self> {
+        let mut config = StealthConfig::default();
+        configure(&mut config);
+        Self::launch_with_config(config).await
+    }
+
     /// Launch with custom config
     pub async fn launch_with_config(config: StealthConfig) -> Result<Self> {
         let config = Arc::new(config);

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -178,7 +178,7 @@ impl Browser {
                 _ => None,
             };
             let transport =
-                Transport::new_with_options(child, &ws_url, proxy_auth, config.cdp_timeout)?;
+                Transport::new_with_options(child, &ws_url, proxy_auth, config.cdp_timeout).await?;
             let connection = Connection::new(transport);
 
             let version = connection.version().await?;
@@ -225,7 +225,8 @@ impl Browser {
             ws_url,
             config.cdp_timeout,
             config.filter_cdp,
-        )?;
+        )
+        .await?;
         let connection = Connection::new(transport);
         let version = connection.version().await?;
         tracing::info!("Connected to Chrome: {}", version.product);

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -81,8 +81,11 @@ fn stealth_args(config: &StealthConfig, fingerprint: &Fingerprint) -> Vec<String
 /// Info about an open tab
 #[derive(Debug, Clone)]
 pub struct TabInfo {
+    /// Target ID of the tab.
     pub id: String,
+    /// Tab title.
     pub title: String,
+    /// URL currently loaded in the tab.
     pub url: String,
 }
 

--- a/src/cdp/connection.rs
+++ b/src/cdp/connection.rs
@@ -15,7 +15,7 @@ pub struct Connection {
 
 impl Connection {
     /// Create a new connection wrapping a transport
-    pub fn new(transport: Transport) -> Self {
+    pub(crate) fn new(transport: Transport) -> Self {
         Self {
             transport: Arc::new(transport),
         }
@@ -27,14 +27,14 @@ impl Connection {
     }
 
     /// Get browser version info
-    pub async fn version(&self) -> Result<BrowserGetVersionResult> {
+    pub(crate) async fn version(&self) -> Result<BrowserGetVersionResult> {
         self.transport
             .send("Browser.getVersion", &BrowserGetVersion {})
             .await
     }
 
     /// Create a new target (tab)
-    pub async fn create_target(
+    pub(crate) async fn create_target(
         &self,
         url: &str,
         width: Option<u32>,
@@ -55,7 +55,7 @@ impl Connection {
     }
 
     /// Attach to a target and get a session
-    pub async fn attach_to_target(&self, target_id: &str) -> Result<Session> {
+    pub(crate) async fn attach_to_target(&self, target_id: &str) -> Result<Session> {
         let result: TargetAttachToTargetResult = self
             .transport
             .send(
@@ -75,7 +75,7 @@ impl Connection {
     }
 
     /// Close a target
-    pub async fn close_target(&self, target_id: &str) -> Result<bool> {
+    pub(crate) async fn close_target(&self, target_id: &str) -> Result<bool> {
         let result: TargetCloseTargetResult = self
             .transport
             .send(
@@ -89,7 +89,7 @@ impl Connection {
     }
 
     /// Get all targets (tabs)
-    pub async fn get_targets(&self) -> Result<Vec<TargetInfo>> {
+    pub(crate) async fn get_targets(&self) -> Result<Vec<TargetInfo>> {
         let result: TargetGetTargetsResult = self
             .transport
             .send("Target.getTargets", &TargetGetTargets {})
@@ -98,7 +98,7 @@ impl Connection {
     }
 
     /// Activate (focus) a target
-    pub async fn activate_target(&self, target_id: &str) -> Result<()> {
+    pub(crate) async fn activate_target(&self, target_id: &str) -> Result<()> {
         self.send_void(
             "Target.activateTarget",
             &TargetActivateTarget {
@@ -117,7 +117,7 @@ impl Connection {
     }
 
     /// Close the browser
-    pub async fn close(&self) -> Result<()> {
+    pub(crate) async fn close(&self) -> Result<()> {
         let _ = self.send_void("Browser.close", &BrowserClose {}).await;
         self.transport.close().await
     }
@@ -167,18 +167,22 @@ impl Session {
 
     /// Enable the Fetch domain, optionally handling auth challenges (proxy auth).
     /// Must be called per-session (per-tab).
-    pub async fn fetch_enable(&self, handle_auth_requests: bool) -> Result<()> {
+    pub(crate) async fn fetch_enable(&self, handle_auth_requests: bool) -> Result<()> {
         self.fetch_enable_interception(vec![], handle_auth_requests)
             .await
     }
 
     /// Enable page events
-    pub async fn page_enable(&self) -> Result<()> {
+    pub(crate) async fn page_enable(&self) -> Result<()> {
         self.send_void("Page.enable", &PageEnable {}).await
     }
 
     /// Navigate to a URL, optionally with a custom Referer header
-    pub async fn navigate(&self, url: &str, referrer: Option<&str>) -> Result<PageNavigateResult> {
+    pub(crate) async fn navigate(
+        &self,
+        url: &str,
+        referrer: Option<&str>,
+    ) -> Result<PageNavigateResult> {
         self.send(
             "Page.navigate",
             &PageNavigate {
@@ -191,7 +195,7 @@ impl Session {
 
     /// Set extra HTTP headers sent with every request on this session.
     /// Pass an empty map to clear previously set headers.
-    pub async fn set_extra_headers(
+    pub(crate) async fn set_extra_headers(
         &self,
         headers: std::collections::HashMap<String, String>,
     ) -> Result<()> {
@@ -203,13 +207,13 @@ impl Session {
     }
 
     /// Remove all extra HTTP headers previously set via set_extra_headers.
-    pub async fn clear_extra_headers(&self) -> Result<()> {
+    pub(crate) async fn clear_extra_headers(&self) -> Result<()> {
         self.set_extra_headers(std::collections::HashMap::new())
             .await
     }
 
     /// Clear all browser cookies for this context.
-    pub async fn clear_all_cookies(&self) -> Result<()> {
+    pub(crate) async fn clear_all_cookies(&self) -> Result<()> {
         self.send_void(
             "Network.clearBrowserCookies",
             &NetworkClearBrowserCookies {},
@@ -218,20 +222,20 @@ impl Session {
     }
 
     /// Bulk-set multiple cookies at once.
-    pub async fn set_cookies(&self, cookies: Vec<NetworkSetCookie>) -> Result<()> {
+    pub(crate) async fn set_cookies(&self, cookies: Vec<NetworkSetCookie>) -> Result<()> {
         self.send_void("Network.setCookies", &NetworkSetCookies { cookies })
             .await
     }
 
     /// Bypass CSP enforcement for the current page.
     /// Must be called before navigation to take effect.
-    pub async fn set_bypass_csp(&self, enabled: bool) -> Result<()> {
+    pub(crate) async fn set_bypass_csp(&self, enabled: bool) -> Result<()> {
         self.send_void("Page.setBypassCSP", &PageSetBypassCSP { enabled })
             .await
     }
 
     /// Override the User-Agent string (and optionally Accept-Language).
-    pub async fn set_user_agent(
+    pub(crate) async fn set_user_agent(
         &self,
         user_agent: &str,
         accept_language: Option<&str>,
@@ -249,7 +253,7 @@ impl Session {
     }
 
     /// Override the User-Agent together with its client-hint metadata.
-    pub async fn set_user_agent_full(
+    pub(crate) async fn set_user_agent_full(
         &self,
         override_opts: EmulationSetUserAgentOverride,
     ) -> Result<()> {
@@ -258,7 +262,7 @@ impl Session {
     }
 
     /// Ignore TLS certificate errors for this session.
-    pub async fn set_ignore_cert_errors(&self, ignore: bool) -> Result<()> {
+    pub(crate) async fn set_ignore_cert_errors(&self, ignore: bool) -> Result<()> {
         self.send_void(
             "Security.setIgnoreCertificateErrors",
             &SecuritySetIgnoreCertificateErrors { ignore },
@@ -268,7 +272,11 @@ impl Session {
 
     /// Accept or dismiss a JavaScript dialog (alert / confirm / prompt).
     /// `prompt_text` is only used for prompt() dialogs.
-    pub async fn handle_dialog(&self, accept: bool, prompt_text: Option<&str>) -> Result<()> {
+    pub(crate) async fn handle_dialog(
+        &self,
+        accept: bool,
+        prompt_text: Option<&str>,
+    ) -> Result<()> {
         self.send_void(
             "Page.handleJavaScriptDialog",
             &PageHandleJavaScriptDialog {
@@ -281,7 +289,7 @@ impl Session {
 
     /// Enable Fetch domain request interception with URL patterns.
     /// `patterns` — list of URL/resource-type filters; empty matches everything.
-    pub async fn fetch_enable_interception(
+    pub(crate) async fn fetch_enable_interception(
         &self,
         patterns: Vec<RequestPattern>,
         handle_auth: bool,
@@ -301,12 +309,14 @@ impl Session {
     }
 
     /// Disable Fetch domain interception.
-    pub async fn fetch_disable(&self) -> Result<()> {
+    #[allow(dead_code)] // request-interception wrapper, kept for completeness
+    pub(crate) async fn fetch_disable(&self) -> Result<()> {
         self.send_void("Fetch.disable", &FetchDisable {}).await
     }
 
     /// Continue an intercepted request, optionally modifying URL/method/headers/body.
-    pub async fn fetch_continue(
+    #[allow(dead_code)] // request-interception wrapper, kept for completeness
+    pub(crate) async fn fetch_continue(
         &self,
         request_id: &str,
         url: Option<&str>,
@@ -330,7 +340,8 @@ impl Session {
 
     /// Fulfill an intercepted request with a synthetic response.
     /// `body` will be base64-encoded automatically.
-    pub async fn fetch_fulfill(
+    #[allow(dead_code)] // request-interception wrapper, kept for completeness
+    pub(crate) async fn fetch_fulfill(
         &self,
         request_id: &str,
         status_code: u16,
@@ -356,7 +367,8 @@ impl Session {
 
     /// Abort an intercepted request with a network error.
     /// `error_reason`: "Aborted", "AccessDenied", "AddressUnreachable", "ConnectionRefused", etc.
-    pub async fn fetch_fail(&self, request_id: &str, error_reason: &str) -> Result<()> {
+    #[allow(dead_code)] // request-interception wrapper, kept for completeness
+    pub(crate) async fn fetch_fail(&self, request_id: &str, error_reason: &str) -> Result<()> {
         self.send_void(
             "Fetch.failRequest",
             &FetchFailRequest {
@@ -368,7 +380,7 @@ impl Session {
     }
 
     /// Reload the page
-    pub async fn reload(&self, ignore_cache: bool) -> Result<()> {
+    pub(crate) async fn reload(&self, ignore_cache: bool) -> Result<()> {
         self.send_void(
             "Page.reload",
             &PageReload {
@@ -399,17 +411,20 @@ impl Session {
     }
 
     /// Go back in history
-    pub async fn go_back(&self) -> Result<()> {
+    pub(crate) async fn go_back(&self) -> Result<()> {
         self.navigate_history(-1).await
     }
 
     /// Go forward in history
-    pub async fn go_forward(&self) -> Result<()> {
+    pub(crate) async fn go_forward(&self) -> Result<()> {
         self.navigate_history(1).await
     }
 
     /// Add a script to evaluate on every new document
-    pub async fn add_script_to_evaluate_on_new_document(&self, source: &str) -> Result<String> {
+    pub(crate) async fn add_script_to_evaluate_on_new_document(
+        &self,
+        source: &str,
+    ) -> Result<String> {
         let result: PageAddScriptToEvaluateOnNewDocumentResult = self
             .send(
                 "Page.addScriptToEvaluateOnNewDocument",
@@ -424,7 +439,7 @@ impl Session {
     }
 
     /// Capture a screenshot
-    pub async fn capture_screenshot(
+    pub(crate) async fn capture_screenshot(
         &self,
         format: Option<&str>,
         quality: Option<u8>,
@@ -449,14 +464,14 @@ impl Session {
     }
 
     /// Get the frame tree
-    pub async fn get_frame_tree(&self) -> Result<FrameTree> {
+    pub(crate) async fn get_frame_tree(&self) -> Result<FrameTree> {
         let result: PageGetFrameTreeResult =
             self.send("Page.getFrameTree", &PageGetFrameTree {}).await?;
         Ok(result.frame_tree)
     }
 
     /// Dispatch a mouse event (click, move, or wheel)
-    pub async fn dispatch_mouse_event(
+    pub(crate) async fn dispatch_mouse_event(
         &self,
         event_type: MouseEventType,
         x: f64,
@@ -477,7 +492,7 @@ impl Session {
     }
 
     /// Dispatch a mouse wheel scroll event
-    pub async fn dispatch_mouse_wheel(
+    pub(crate) async fn dispatch_mouse_wheel(
         &self,
         x: f64,
         y: f64,
@@ -497,12 +512,15 @@ impl Session {
     }
 
     /// Dispatch a raw mouse event with full control over all fields
-    pub async fn dispatch_mouse_event_full(&self, event: InputDispatchMouseEvent) -> Result<()> {
+    pub(crate) async fn dispatch_mouse_event_full(
+        &self,
+        event: InputDispatchMouseEvent,
+    ) -> Result<()> {
         self.send_void("Input.dispatchMouseEvent", &event).await
     }
 
     /// Dispatch a key event
-    pub async fn dispatch_key_event(
+    pub(crate) async fn dispatch_key_event(
         &self,
         event_type: KeyEventType,
         key: Option<&str>,
@@ -522,7 +540,7 @@ impl Session {
     }
 
     /// Insert text at current cursor position
-    pub async fn insert_text(&self, text: &str) -> Result<()> {
+    pub(crate) async fn insert_text(&self, text: &str) -> Result<()> {
         self.send_void(
             "Input.insertText",
             &InputInsertText {
@@ -533,7 +551,7 @@ impl Session {
     }
 
     /// Get the document root node
-    pub async fn get_document(&self, depth: Option<i32>) -> Result<DOMNode> {
+    pub(crate) async fn get_document(&self, depth: Option<i32>) -> Result<DOMNode> {
         let result: DOMGetDocumentResult = self
             .send(
                 "DOM.getDocument",
@@ -547,7 +565,7 @@ impl Session {
     }
 
     /// Query for a single element
-    pub async fn query_selector(&self, node_id: i32, selector: &str) -> Result<i32> {
+    pub(crate) async fn query_selector(&self, node_id: i32, selector: &str) -> Result<i32> {
         let result: DOMQuerySelectorResult = self
             .send(
                 "DOM.querySelector",
@@ -561,7 +579,11 @@ impl Session {
     }
 
     /// Query for all matching elements
-    pub async fn query_selector_all(&self, node_id: i32, selector: &str) -> Result<Vec<i32>> {
+    pub(crate) async fn query_selector_all(
+        &self,
+        node_id: i32,
+        selector: &str,
+    ) -> Result<Vec<i32>> {
         let result: DOMQuerySelectorAllResult = self
             .send(
                 "DOM.querySelectorAll",
@@ -575,7 +597,7 @@ impl Session {
     }
 
     /// Get the box model for an element
-    pub async fn get_box_model(&self, node_id: i32) -> Result<BoxModel> {
+    pub(crate) async fn get_box_model(&self, node_id: i32) -> Result<BoxModel> {
         let result: DOMGetBoxModelResult = self
             .send(
                 "DOM.getBoxModel",
@@ -588,7 +610,7 @@ impl Session {
     }
 
     /// Get outer HTML of an element
-    pub async fn get_outer_html(&self, node_id: i32) -> Result<String> {
+    pub(crate) async fn get_outer_html(&self, node_id: i32) -> Result<String> {
         let result: DOMGetOuterHTMLResult = self
             .send(
                 "DOM.getOuterHTML",
@@ -601,7 +623,7 @@ impl Session {
     }
 
     /// Resolve a DOM node to a Runtime remote object ID
-    pub async fn resolve_node(&self, node_id: i32) -> Result<String> {
+    pub(crate) async fn resolve_node(&self, node_id: i32) -> Result<String> {
         let result: DOMResolveNodeResult = self
             .send(
                 "DOM.resolveNode",
@@ -618,7 +640,7 @@ impl Session {
     }
 
     /// Call a function on a remote object and return the result by value
-    pub async fn call_function_on(
+    pub(crate) async fn call_function_on(
         &self,
         object_id: &str,
         function_declaration: &str,
@@ -628,7 +650,7 @@ impl Session {
     }
 
     /// Focus an element
-    pub async fn focus(&self, node_id: i32) -> Result<()> {
+    pub(crate) async fn focus(&self, node_id: i32) -> Result<()> {
         self.send_void(
             "DOM.focus",
             &DOMFocus {
@@ -639,7 +661,7 @@ impl Session {
     }
 
     /// Get all cookies
-    pub async fn get_cookies(&self, urls: Option<Vec<String>>) -> Result<Vec<Cookie>> {
+    pub(crate) async fn get_cookies(&self, urls: Option<Vec<String>>) -> Result<Vec<Cookie>> {
         let result: NetworkGetCookiesResult = self
             .send("Network.getCookies", &NetworkGetCookies { urls })
             .await?;
@@ -647,7 +669,7 @@ impl Session {
     }
 
     /// Set a cookie
-    pub async fn set_cookie(
+    pub(crate) async fn set_cookie(
         &self,
         name: &str,
         value: &str,
@@ -672,7 +694,7 @@ impl Session {
     }
 
     /// Delete cookies
-    pub async fn delete_cookies(
+    pub(crate) async fn delete_cookies(
         &self,
         name: &str,
         url: Option<&str>,
@@ -692,7 +714,7 @@ impl Session {
 
     /// Enable network events (request/response capture)
     /// NOTE: This enables Network.enable which may be slightly detectable
-    pub async fn network_enable(&self) -> Result<()> {
+    pub(crate) async fn network_enable(&self) -> Result<()> {
         self.send_void(
             "Network.enable",
             &NetworkEnable {
@@ -703,12 +725,12 @@ impl Session {
     }
 
     /// Disable network events
-    pub async fn network_disable(&self) -> Result<()> {
+    pub(crate) async fn network_disable(&self) -> Result<()> {
         self.send_void("Network.disable", &NetworkDisable {}).await
     }
 
     /// Get response body for a request
-    pub async fn get_response_body(&self, request_id: &str) -> Result<(String, bool)> {
+    pub(crate) async fn get_response_body(&self, request_id: &str) -> Result<(String, bool)> {
         let result: NetworkGetResponseBodyResult = self
             .send(
                 "Network.getResponseBody",
@@ -721,7 +743,7 @@ impl Session {
     }
 
     /// Evaluate JavaScript and return a remote object reference (not by value).
-    pub async fn evaluate_for_remote_object(
+    pub(crate) async fn evaluate_for_remote_object(
         &self,
         expression: &str,
     ) -> Result<RuntimeEvaluateResult> {
@@ -730,7 +752,7 @@ impl Session {
     }
 
     /// Convert a remote object ID to a DOM node_id via DOM.requestNode
-    pub async fn request_node(&self, object_id: &str) -> Result<i32> {
+    pub(crate) async fn request_node(&self, object_id: &str) -> Result<i32> {
         let result: DOMRequestNodeResult = self
             .send(
                 "DOM.requestNode",
@@ -743,7 +765,7 @@ impl Session {
     }
 
     /// Get all own properties of a remote object (used for array element enumeration)
-    pub async fn get_properties(
+    pub(crate) async fn get_properties(
         &self,
         object_id: &str,
     ) -> Result<Vec<crate::cdp::types::PropertyDescriptor>> {
@@ -785,13 +807,13 @@ impl Session {
     }
 
     /// Evaluate JavaScript expression and return the result by value
-    pub async fn evaluate(&self, expression: &str) -> Result<RuntimeEvaluateResult> {
+    pub(crate) async fn evaluate(&self, expression: &str) -> Result<RuntimeEvaluateResult> {
         self.evaluate_impl(expression, true, None, true).await
     }
 
     /// Evaluate JavaScript synchronously (don't await promises).
     /// Use this when the page may have unresolved promises that would block.
-    pub async fn evaluate_sync(&self, expression: &str) -> Result<RuntimeEvaluateResult> {
+    pub(crate) async fn evaluate_sync(&self, expression: &str) -> Result<RuntimeEvaluateResult> {
         self.evaluate_impl(expression, true, None, false).await
     }
 
@@ -815,7 +837,11 @@ impl Session {
     }
 
     /// Set files for a file input element
-    pub async fn set_file_input_files(&self, node_id: i32, files: Vec<String>) -> Result<()> {
+    pub(crate) async fn set_file_input_files(
+        &self,
+        node_id: i32,
+        files: Vec<String>,
+    ) -> Result<()> {
         self.send_void(
             "DOM.setFileInputFiles",
             &DOMSetFileInputFiles {
@@ -829,7 +855,10 @@ impl Session {
     }
 
     /// Dispatch a key event with full modifier support
-    pub async fn dispatch_key_event_full(&self, event: InputDispatchKeyEventFull) -> Result<()> {
+    pub(crate) async fn dispatch_key_event_full(
+        &self,
+        event: InputDispatchKeyEventFull,
+    ) -> Result<()> {
         self.send_void("Input.dispatchKeyEvent", &event).await
     }
 }

--- a/src/cdp/connection.rs
+++ b/src/cdp/connection.rs
@@ -123,7 +123,9 @@ impl Connection {
     }
 }
 
-/// A CDP session attached to a specific target
+/// A CDP session attached to a specific target. Cheap to clone (an `Arc` + two
+/// small strings) — clones share the same underlying transport/target.
+#[derive(Clone)]
 pub struct Session {
     transport: Arc<Transport>,
     session_id: String,

--- a/src/cdp/connection.rs
+++ b/src/cdp/connection.rs
@@ -612,11 +612,7 @@ impl Session {
         result
             .object
             .object_id
-            .ok_or_else(|| crate::error::Error::Cdp {
-                method: "DOM.resolveNode".to_string(),
-                code: -1,
-                message: "No object_id returned".to_string(),
-            })
+            .ok_or_else(|| crate::error::Error::cdp("DOM.resolveNode", -1, "No object_id returned"))
     }
 
     /// Call a function on a remote object and return the result by value

--- a/src/cdp/discover.rs
+++ b/src/cdp/discover.rs
@@ -20,13 +20,18 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
 /// One entry from `GET /json` — a single browsing target (tab, iframe, worker).
 #[derive(Debug, Clone, Deserialize)]
 pub struct PageTarget {
+    /// Target ID.
     pub id: String,
+    /// Target title.
     #[serde(default)]
     pub title: String,
+    /// Target type (e.g. "page", "iframe", "worker").
     #[serde(rename = "type", default)]
     pub kind: String,
+    /// URL loaded in the target.
     #[serde(default)]
     pub url: String,
+    /// Per-target DevTools WebSocket URL.
     #[serde(rename = "webSocketDebuggerUrl", default)]
     pub web_socket_debugger_url: String,
 }

--- a/src/cdp/mod.rs
+++ b/src/cdp/mod.rs
@@ -12,9 +12,13 @@
 pub mod connection;
 pub mod discover;
 pub mod transport;
-pub mod types;
+pub(crate) mod types;
 
+// Deliberate low-level escape hatch: `Connection`/`Session` (with only their
+// generic `send` + accessors public) and `Transport`. The hand-written
+// `cdp::types` structs stay crate-private so adding a CDP field is never a
+// breaking change.
 pub use connection::{Connection, Session};
 pub use discover::{auto_connect, discover_browser_ws, discover_pages, PageTarget};
 pub use transport::Transport;
-pub use types::*;
+pub(crate) use types::*;

--- a/src/cdp/transport.rs
+++ b/src/cdp/transport.rs
@@ -1,24 +1,43 @@
 //! CDP Transport Layer
 //!
-//! Handles communication with Chrome via WebSocket.
+//! Handles communication with Chrome via WebSocket (tokio-tungstenite).
 //! Includes built-in filtering to block detectable CDP commands.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
-use std::net::TcpStream;
 use std::process::{Child, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt, StreamExt};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, oneshot, Mutex};
-
-/// Pending requests map - uses std::sync::Mutex because it's accessed from both
-/// a std thread (reader loop) and async contexts, and the lock is held very briefly.
-type PendingMap = std::sync::Mutex<HashMap<u64, PendingRequest>>;
+use tokio::net::TcpStream;
+use tokio::sync::{broadcast, oneshot, Mutex};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 use crate::error::{Error, Result};
+
+/// The connected WebSocket stream and its split write/read halves.
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type WsSink = SplitSink<WsStream, Message>;
+type WsSource = SplitStream<WsStream>;
+
+/// Shared write half — used by both `send_impl` and the reader task
+/// (proxy-auth replies, pong frames).
+type SharedSink = Arc<Mutex<WsSink>>;
+
+/// Pending requests map — accessed from both the async reader task and
+/// `send_impl`; the lock is held very briefly so a std Mutex is fine.
+type PendingMap = std::sync::Mutex<HashMap<u64, PendingRequest>>;
+
+/// A pending request waiting for a response
+type PendingRequest = oneshot::Sender<Result<Value>>;
+
+/// Broadcast capacity for CDP events (multi-consumer, lag observable).
+const EVENT_CHANNEL_CAP: usize = 1024;
 
 /// Check if a command should be blocked (highly detectable by anti-bot)
 fn is_blocked(method: &str) -> bool {
@@ -48,166 +67,24 @@ fn is_risky(method: &str) -> bool {
     )
 }
 
-/// A pending request waiting for a response
-type PendingRequest = oneshot::Sender<Result<Value>>;
-
-/// WebSocket message types
-mod ws {
-    pub const OPCODE_CONTINUATION: u8 = 0x0;
-    pub const OPCODE_TEXT: u8 = 0x1;
-    pub const OPCODE_BINARY: u8 = 0x2;
-    pub const OPCODE_CLOSE: u8 = 0x8;
-    pub const OPCODE_PING: u8 = 0x9;
-    pub const OPCODE_PONG: u8 = 0xA;
-}
-
-/// Simple WebSocket frame writer (text opcode)
-fn write_ws_frame(stream: &mut TcpStream, data: &[u8]) -> std::io::Result<()> {
-    write_ws_frame_with_opcode(stream, ws::OPCODE_TEXT, data)
-}
-
-/// WebSocket frame writer with explicit opcode
-fn write_ws_frame_with_opcode(
-    stream: &mut TcpStream,
-    opcode: u8,
-    data: &[u8],
-) -> std::io::Result<()> {
-    use std::io::Write;
-
-    let len = data.len();
-    let mut frame = Vec::with_capacity(14 + len);
-
-    // FIN + opcode
-    frame.push(0x80 | opcode);
-
-    // Mask bit set (client must mask), then length
-    if len < 126 {
-        frame.push(0x80 | len as u8);
-    } else if len < 65536 {
-        frame.push(0x80 | 126);
-        frame.push((len >> 8) as u8);
-        frame.push(len as u8);
-    } else {
-        frame.push(0x80 | 127);
-        for i in (0..8).rev() {
-            frame.push((len >> (i * 8)) as u8);
-        }
-    }
-
-    // Random masking key per frame (RFC 6455 compliance)
-    let mask: [u8; 4] = [
-        fastrand::u8(..),
-        fastrand::u8(..),
-        fastrand::u8(..),
-        fastrand::u8(..),
-    ];
-    frame.extend_from_slice(&mask);
-
-    // Masked payload
-    for (i, byte) in data.iter().enumerate() {
-        frame.push(byte ^ mask[i % 4]);
-    }
-
-    stream.write_all(&frame)?;
-    stream.flush()?;
-    Ok(())
-}
-
-/// Read exactly `buf.len()` bytes of a frame in progress; a mid-frame timeout
-/// desyncs the stream, so remap it to a fatal error.
-fn read_frame_bytes(stream: &mut TcpStream, buf: &mut [u8]) -> std::io::Result<()> {
-    use std::io::Read;
-    match stream.read_exact(buf) {
-        Ok(()) => Ok(()),
-        Err(e)
-            if e.kind() == std::io::ErrorKind::WouldBlock
-                || e.kind() == std::io::ErrorKind::TimedOut =>
-        {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::ConnectionAborted,
-                format!("mid-frame read timeout (stream desynced): {}", e),
-            ))
-        }
-        Err(e) => Err(e),
-    }
-}
-
-/// Read a WebSocket frame, returns (fin, opcode, payload). A timeout on the first
-/// header byte is a recoverable idle timeout; mid-frame timeouts are fatal.
-fn read_ws_frame(stream: &mut TcpStream) -> std::io::Result<(bool, u8, Vec<u8>)> {
-    use std::io::Read;
-
-    let mut first = [0u8; 1];
-    stream.read_exact(&mut first)?;
-
-    let mut second = [0u8; 1];
-    read_frame_bytes(stream, &mut second)?;
-
-    let fin = (first[0] & 0x80) != 0;
-    let opcode = first[0] & 0x0F;
-    let masked = (second[0] & 0x80) != 0;
-    let mut len = (second[0] & 0x7F) as usize;
-
-    if len == 126 {
-        let mut ext = [0u8; 2];
-        read_frame_bytes(stream, &mut ext)?;
-        len = ((ext[0] as usize) << 8) | (ext[1] as usize);
-    } else if len == 127 {
-        let mut ext = [0u8; 8];
-        read_frame_bytes(stream, &mut ext)?;
-        const MAX_FRAME_LEN: usize = 256 * 1024 * 1024;
-        len = 0;
-        for byte in ext.iter() {
-            // Use checked_shl to prevent silent overflow on 32-bit platforms
-            len = match len.checked_shl(8) {
-                Some(shifted) => shifted | (*byte as usize),
-                None => MAX_FRAME_LEN + 1, // force the size check below to trigger
-            };
-            if len > MAX_FRAME_LEN {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("WebSocket frame too large: {} bytes", len),
-                ));
-            }
-        }
-    }
-
-    let mask = if masked {
-        let mut m = [0u8; 4];
-        read_frame_bytes(stream, &mut m)?;
-        Some(m)
-    } else {
-        None
-    };
-
-    let mut payload = vec![0u8; len];
-    read_frame_bytes(stream, &mut payload)?;
-
-    if let Some(mask) = mask {
-        for (i, byte) in payload.iter_mut().enumerate() {
-            *byte ^= mask[i % 4];
-        }
-    }
-
-    Ok((fin, opcode, payload))
-}
-
 /// CDP Transport - handles sending commands and receiving responses via WebSocket
 pub struct Transport {
     /// The Chrome child process (None when connecting to an existing instance)
     child: Option<Mutex<Child>>,
-    /// WebSocket stream for writing (shared with proxy auth via Arc)
-    writer: Arc<std::sync::Mutex<TcpStream>>,
+    /// WebSocket write half (shared with the reader task for auth/pong).
+    writer: SharedSink,
     /// Next message ID
     next_id: AtomicU64,
     /// Pending requests waiting for responses
     pending: Arc<PendingMap>,
-    /// Channel to receive parsed messages from the reader task
-    event_rx: Mutex<mpsc::Receiver<CdpMessage>>,
+    /// Broadcasts parsed events to all subscribers.
+    event_tx: broadcast::Sender<CdpMessage>,
+    /// Persistent receiver backing `recv_event`/`try_recv_event` (back-compat).
+    event_rx: Mutex<broadcast::Receiver<CdpMessage>>,
     /// Timeout for CDP commands
     cmd_timeout: std::time::Duration,
-    /// Reader thread handle — checked for panics before sending commands
-    reader_handle: Option<std::thread::JoinHandle<()>>,
+    /// Reader task handle — checked for exit before sending commands.
+    reader_handle: Option<tokio::task::JoinHandle<()>>,
     /// When true, drop "detectable" commands (`Runtime.enable`, etc.) silently.
     /// Defaults to true. Disable when you own the browser session and need
     /// full DevTools-equivalent control.
@@ -215,7 +92,7 @@ pub struct Transport {
 }
 
 /// A parsed CDP message (response or event)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CdpMessage {
     Response {
         id: u64,
@@ -230,139 +107,78 @@ pub enum CdpMessage {
 
 impl Transport {
     /// Create a new transport connecting to Chrome via WebSocket
-    pub fn new(child: Child, ws_url: &str) -> Result<Self> {
-        Self::new_with_options(child, ws_url, None, 30)
+    pub async fn new(child: Child, ws_url: &str) -> Result<Self> {
+        Self::new_with_options(child, ws_url, None, 30).await
     }
 
-    /// Perform WebSocket handshake and return the connected stream.
-    fn ws_handshake(ws_url: &str) -> Result<TcpStream> {
+    /// Connect the WebSocket and return the stream.
+    async fn ws_connect(ws_url: &str) -> Result<WsStream> {
         if !ws_url.starts_with("ws://") {
             return Err(Error::transport(format!(
                 "Invalid WebSocket URL (expected ws://...): {}",
                 ws_url
             )));
         }
-        let url = ws_url.trim_start_matches("ws://");
-        let (host_port, _path) = url.split_once('/').unwrap_or((url, ""));
-
-        let mut stream = TcpStream::connect(host_port)
-            .map_err(|e| Error::transport_io("Failed to connect to Chrome", e))?;
-
-        let path = format!("/{}", url.split_once('/').map(|(_, p)| p).unwrap_or(""));
-        let key = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, {
-            let mut buf = [0u8; 16];
-            for b in buf.iter_mut() {
-                *b = fastrand::u8(..);
-            }
-            buf
-        });
-
-        let handshake = format!(
-            "GET {} HTTP/1.1\r\n\
-             Host: {}\r\n\
-             Upgrade: websocket\r\n\
-             Connection: Upgrade\r\n\
-             Sec-WebSocket-Key: {}\r\n\
-             Sec-WebSocket-Version: 13\r\n\
-             \r\n",
-            path, host_port, key
-        );
-
-        use std::io::{BufRead, Write};
-        stream
-            .write_all(handshake.as_bytes())
-            .map_err(|e| Error::transport_io("Handshake write failed", e))?;
-
-        // Read handshake response until end of HTTP headers.
-        let mut reader = std::io::BufReader::new(&stream);
-        let mut response_buf = Vec::with_capacity(1024);
-        loop {
-            let available = reader
-                .fill_buf()
-                .map_err(|e| Error::transport_io("Handshake read failed", e))?;
-            if available.is_empty() {
-                return Err(Error::transport(
-                    "Connection closed during WebSocket handshake",
-                ));
-            }
-            let len = available.len();
-            response_buf.extend_from_slice(available);
-            reader.consume(len);
-            if response_buf.len() >= 4 && response_buf[response_buf.len() - 4..] == *b"\r\n\r\n" {
-                break;
-            }
-            if response_buf.len() > 8192 {
-                return Err(Error::transport("WebSocket handshake response too large"));
-            }
-        }
-        let response_str = String::from_utf8_lossy(&response_buf);
-
-        if !response_str.starts_with("HTTP/1.1 101") {
-            return Err(Error::transport(format!(
-                "WebSocket handshake failed: {}",
-                response_str
-            )));
-        }
-
+        let (stream, _resp) = connect_async(ws_url)
+            .await
+            .map_err(|e| Error::transport(format!("WebSocket connect failed: {}", e)))?;
         tracing::debug!("WebSocket connected to {}", ws_url);
         Ok(stream)
     }
 
-    /// Spawn the reader thread and build the Transport from a handshaked stream.
+    /// Spawn the reader task and build the Transport from a connected stream.
     fn build(
         child: Option<Child>,
-        stream: TcpStream,
+        stream: WsStream,
         proxy_auth: Option<(String, String)>,
         cdp_timeout_secs: u64,
         filter_cdp: bool,
-    ) -> Result<Self> {
+    ) -> Self {
         let cmd_timeout = std::time::Duration::from_secs(cdp_timeout_secs);
         tracing::debug!("CDP timeout set to {}s", cdp_timeout_secs);
 
-        // Clone stream for reader — set TCP read timeout as safety net
-        let reader_stream = stream
-            .try_clone()
-            .map_err(|e| Error::transport_io("Failed to clone stream", e))?;
-        reader_stream
-            .set_read_timeout(Some(std::time::Duration::from_secs(cdp_timeout_secs * 4)))
-            .map_err(|e| Error::transport_io("Failed to set read timeout", e))?;
-
-        let writer = Arc::new(std::sync::Mutex::new(stream));
-
-        // If proxy auth is configured, share the writer so auth responses
-        // don't race with command writes on the TCP stream.
-        let proxy_auth_writer =
-            proxy_auth.map(|(username, password)| (username, password, Arc::clone(&writer)));
+        let (sink, source) = stream.split();
+        let writer: SharedSink = Arc::new(Mutex::new(sink));
 
         let pending: Arc<PendingMap> = Arc::new(std::sync::Mutex::new(HashMap::new()));
-        let (event_tx, event_rx) = mpsc::channel(256);
+        let (event_tx, event_rx) = broadcast::channel(EVENT_CHANNEL_CAP);
 
         let pending_clone = Arc::clone(&pending);
-        let reader_handle = std::thread::spawn(move || {
-            Self::reader_loop(reader_stream, pending_clone, event_tx, proxy_auth_writer);
+        let event_tx_clone = event_tx.clone();
+        let reader_writer = Arc::clone(&writer);
+        let reader_handle = tokio::spawn(async move {
+            Self::reader_loop(
+                source,
+                pending_clone,
+                event_tx_clone,
+                reader_writer,
+                proxy_auth,
+            )
+            .await;
         });
 
-        Ok(Self {
+        Self {
             child: child.map(Mutex::new),
             writer,
             next_id: AtomicU64::new(1),
             pending,
+            event_tx,
             event_rx: Mutex::new(event_rx),
             cmd_timeout,
             reader_handle: Some(reader_handle),
             filter_cdp,
-        })
+        }
     }
 
     /// Create a new transport with proxy auth and configurable CDP timeout.
-    pub fn new_with_options(
+    pub async fn new_with_options(
         mut child: Child,
         ws_url: &str,
         proxy_auth: Option<(String, String)>,
         cdp_timeout_secs: u64,
     ) -> Result<Self> {
-        // Kill the child if the handshake fails, so it can't orphan Chrome.
-        let stream = match Self::ws_handshake(ws_url) {
+        // Kill the child if the connect fails, so it can't orphan Chrome.
+        let stream = match Self::ws_connect(ws_url).await {
             Ok(s) => s,
             Err(e) => {
                 let _ = child.kill();
@@ -370,245 +186,171 @@ impl Transport {
                 return Err(e);
             }
         };
-        Self::build(Some(child), stream, proxy_auth, cdp_timeout_secs, true)
+        Ok(Self::build(
+            Some(child),
+            stream,
+            proxy_auth,
+            cdp_timeout_secs,
+            true,
+        ))
     }
 
     /// Connect to an existing Chrome instance at the given WebSocket URL.
     /// Does not manage a Chrome process — caller owns the browser lifecycle.
-    pub fn connect(ws_url: &str, cdp_timeout_secs: u64) -> Result<Self> {
-        let stream = Self::ws_handshake(ws_url)?;
-        Self::build(None, stream, None, cdp_timeout_secs, true)
+    pub async fn connect(ws_url: &str, cdp_timeout_secs: u64) -> Result<Self> {
+        let stream = Self::ws_connect(ws_url).await?;
+        Ok(Self::build(None, stream, None, cdp_timeout_secs, true))
     }
 
     /// Connect to an existing Chrome with full options control. Use
     /// `filter_cdp = false` to allow `Runtime.enable` and friends — needed
     /// when driving a user-owned browser where stealth filtering is unwanted.
-    pub fn connect_with_options(
+    pub async fn connect_with_options(
         ws_url: &str,
         cdp_timeout_secs: u64,
         filter_cdp: bool,
     ) -> Result<Self> {
-        let stream = Self::ws_handshake(ws_url)?;
-        Self::build(None, stream, None, cdp_timeout_secs, filter_cdp)
+        let stream = Self::ws_connect(ws_url).await?;
+        Ok(Self::build(
+            None,
+            stream,
+            None,
+            cdp_timeout_secs,
+            filter_cdp,
+        ))
     }
 
-    /// Reader loop - runs in a separate thread to read from WebSocket.
-    /// If `proxy_auth` is provided, `Fetch.authRequired` events are automatically
-    /// answered with `Fetch.continueWithAuth` using the given credentials.
-    fn reader_loop(
-        mut stream: TcpStream,
+    /// Reader task — reads CDP messages off the WebSocket. tokio-tungstenite
+    /// handles framing/fragmentation/close; we only reply to pings and parse
+    /// text payloads. If `proxy_auth` is set, `Fetch.authRequired` events are
+    /// auto-answered with `Fetch.continueWithAuth`.
+    async fn reader_loop(
+        mut source: WsSource,
         pending: Arc<PendingMap>,
-        event_tx: mpsc::Sender<CdpMessage>,
-        proxy_auth: Option<(String, String, Arc<std::sync::Mutex<TcpStream>>)>,
+        event_tx: broadcast::Sender<CdpMessage>,
+        writer: SharedSink,
+        proxy_auth: Option<(String, String)>,
     ) {
         let exit_reason;
         // Separate command ID space for auth responses (won't collide with main IDs)
         let mut auth_cmd_id: u64 = u64::MAX / 2;
-        // Track consecutive timeouts to detect a dead connection
-        let mut consecutive_timeouts: u32 = 0;
-        const MAX_CONSECUTIVE_TIMEOUTS: u32 = 3;
-
-        // Reassembly state for fragmented data messages (RFC 6455 §5.4).
-        const MAX_MESSAGE_LEN: usize = 512 * 1024 * 1024;
-        let mut frag_opcode: Option<u8> = None;
-        let mut frag_buf: Vec<u8> = Vec::new();
 
         loop {
-            let (fin, opcode, payload) = match read_ws_frame(&mut stream) {
-                Ok(frame) => {
-                    consecutive_timeouts = 0; // Reset on successful read
-                    frame
-                }
-                Err(e) => {
-                    // Read timeout fired — connection may still be alive.
-                    // Check if there are any pending requests; if so, this is
-                    // suspicious (Chrome should have responded by now).
-                    if e.kind() == std::io::ErrorKind::WouldBlock
-                        || e.kind() == std::io::ErrorKind::TimedOut
-                    {
-                        consecutive_timeouts += 1;
-                        let n_pending = pending.lock().unwrap().len();
-                        if n_pending > 0 {
-                            tracing::warn!(
-                                "WebSocket read timeout ({}/{}) with {} pending request(s)",
-                                consecutive_timeouts,
-                                MAX_CONSECUTIVE_TIMEOUTS,
-                                n_pending
-                            );
-                        }
-                        if consecutive_timeouts >= MAX_CONSECUTIVE_TIMEOUTS {
-                            exit_reason = format!(
-                                "WebSocket connection dead: {} consecutive read timeouts",
-                                consecutive_timeouts
-                            );
-                            tracing::error!("{}", exit_reason);
-                            break;
-                        }
-                        continue;
-                    }
-                    exit_reason = format!("WebSocket read error: {}", e);
-                    tracing::debug!("{}", exit_reason);
-                    break;
-                }
-            };
-
-            // Reassemble fragmented data messages; control frames are handled inline.
-            let message: Vec<u8> = match opcode {
-                ws::OPCODE_PING => {
-                    // RFC 6455 §5.5.3: Pong must echo the ping's payload
-                    if let Err(e) =
-                        write_ws_frame_with_opcode(&mut stream, ws::OPCODE_PONG, &payload)
-                    {
-                        exit_reason = format!("Pong write failed: {}", e);
-                        break;
-                    }
+            let text = match source.next().await {
+                Some(Ok(Message::Text(t))) => t,
+                Some(Ok(Message::Binary(b))) => match String::from_utf8(b) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                },
+                Some(Ok(Message::Ping(payload))) => {
+                    // Split streams don't auto-pong; reply via the shared sink.
+                    let mut w = writer.lock().await;
+                    let _ = w.send(Message::Pong(payload)).await;
                     continue;
                 }
-                ws::OPCODE_PONG => continue,
-                ws::OPCODE_CLOSE => {
+                Some(Ok(Message::Pong(_))) | Some(Ok(Message::Frame(_))) => continue,
+                Some(Ok(Message::Close(_))) => {
                     exit_reason = "WebSocket closed by server".to_string();
                     tracing::debug!("{}", exit_reason);
                     break;
                 }
-                ws::OPCODE_TEXT | ws::OPCODE_BINARY => {
-                    if frag_opcode.is_some() {
-                        tracing::warn!(
-                            "New data frame started mid-fragment; discarding partial message"
-                        );
-                        frag_buf.clear();
-                        frag_opcode = None;
-                    }
-                    if fin {
-                        payload
-                    } else {
-                        frag_opcode = Some(opcode);
-                        frag_buf = payload;
-                        continue;
-                    }
+                Some(Err(e)) => {
+                    exit_reason = format!("WebSocket read error: {}", e);
+                    tracing::debug!("{}", exit_reason);
+                    break;
                 }
-                ws::OPCODE_CONTINUATION => {
-                    if frag_opcode.is_none() {
-                        tracing::warn!("Continuation frame with no message in progress; ignoring");
-                        continue;
-                    }
-                    if frag_buf.len() + payload.len() > MAX_MESSAGE_LEN {
-                        exit_reason = format!(
-                            "Reassembled WebSocket message exceeds {} byte cap",
-                            MAX_MESSAGE_LEN
-                        );
-                        tracing::error!("{}", exit_reason);
-                        break;
-                    }
-                    frag_buf.extend_from_slice(&payload);
-                    if fin {
-                        frag_opcode = None;
-                        std::mem::take(&mut frag_buf)
-                    } else {
-                        continue;
-                    }
+                None => {
+                    exit_reason = "WebSocket stream ended".to_string();
+                    tracing::debug!("{}", exit_reason);
+                    break;
                 }
-                _ => continue,
             };
 
-            {
-                let text = match String::from_utf8(message) {
-                    Ok(s) => s,
-                    Err(_) => continue,
+            let msg: Value = match serde_json::from_str(&text) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("Failed to parse CDP message: {} - {}", e, text);
+                    continue;
+                }
+            };
+
+            // Check if response or event
+            if let Some(id) = msg.get("id").and_then(|v| v.as_u64()) {
+                let result = if let Some(error) = msg.get("error") {
+                    Err(Error::cdp(
+                        msg.get("method")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or("unknown"),
+                        error.get("code").and_then(|c| c.as_i64()).unwrap_or(-1),
+                        error
+                            .get("message")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or("unknown"),
+                    ))
+                } else {
+                    Ok(msg.get("result").cloned().unwrap_or(json!({})))
                 };
 
-                let msg: Value = match serde_json::from_str(&text) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        tracing::warn!("Failed to parse CDP message: {} - {}", e, text);
-                        continue;
-                    }
-                };
+                let mut pending_guard = pending.lock().unwrap();
+                if let Some(sender) = pending_guard.remove(&id) {
+                    let _ = sender.send(result);
+                } else {
+                    tracing::trace!("Response for unknown id: {}", id);
+                }
+            } else if let Some(method) = msg.get("method").and_then(|m| m.as_str()) {
+                let params = msg.get("params").cloned().unwrap_or(json!({}));
+                let session_id = msg
+                    .get("sessionId")
+                    .and_then(|s| s.as_str())
+                    .map(String::from);
 
-                // Check if response or event
-                if let Some(id) = msg.get("id").and_then(|v| v.as_u64()) {
-                    let result = if let Some(error) = msg.get("error") {
-                        Err(Error::cdp(
-                            msg.get("method")
-                                .and_then(|m| m.as_str())
-                                .unwrap_or("unknown"),
-                            error.get("code").and_then(|c| c.as_i64()).unwrap_or(-1),
-                            error
-                                .get("message")
-                                .and_then(|m| m.as_str())
-                                .unwrap_or("unknown"),
-                        ))
-                    } else {
-                        Ok(msg.get("result").cloned().unwrap_or(json!({})))
-                    };
-
-                    let mut pending_guard = pending.lock().unwrap();
-                    if let Some(sender) = pending_guard.remove(&id) {
-                        let _ = sender.send(result);
-                    } else {
-                        tracing::trace!("Response for unknown id: {}", id);
-                    }
-                } else if let Some(method) = msg.get("method").and_then(|m| m.as_str()) {
-                    let params = msg.get("params").cloned().unwrap_or(json!({}));
-                    let session_id = msg
-                        .get("sessionId")
-                        .and_then(|s| s.as_str())
-                        .map(String::from);
-
-                    // Auto-handle proxy auth challenges
-                    if method == "Fetch.authRequired" {
-                        if let Some((ref username, ref password, ref writer)) = proxy_auth {
-                            if let Some(request_id) =
-                                params.get("requestId").and_then(|v| v.as_str())
-                            {
-                                auth_cmd_id += 1;
-                                let mut response = json!({
-                                    "id": auth_cmd_id,
-                                    "method": "Fetch.continueWithAuth",
-                                    "params": {
-                                        "requestId": request_id,
-                                        "authChallengeResponse": {
-                                            "response": "ProvideCredentials",
-                                            "username": username,
-                                            "password": password
-                                        }
-                                    }
-                                });
-                                // Include sessionId if present
-                                if let Some(ref sid) = session_id {
-                                    response["sessionId"] = json!(sid);
-                                }
-                                if let Ok(data) = serde_json::to_string(&response) {
-                                    let mut w = writer.lock().unwrap();
-                                    if let Err(e) = write_ws_frame(&mut w, data.as_bytes()) {
-                                        tracing::error!(
-                                                "Failed to send proxy auth response: {} — connection may be broken",
-                                                e
-                                            );
-                                        exit_reason = format!("Proxy auth write failed: {}", e);
-                                        // Break out of the loop so pending requests
-                                        // get failed immediately instead of hanging.
-                                        break;
-                                    } else {
-                                        tracing::debug!("Auto-responded to proxy auth challenge");
+                // Auto-handle proxy auth challenges
+                if method == "Fetch.authRequired" {
+                    if let Some((ref username, ref password)) = proxy_auth {
+                        if let Some(request_id) = params.get("requestId").and_then(|v| v.as_str()) {
+                            auth_cmd_id += 1;
+                            let mut response = json!({
+                                "id": auth_cmd_id,
+                                "method": "Fetch.continueWithAuth",
+                                "params": {
+                                    "requestId": request_id,
+                                    "authChallengeResponse": {
+                                        "response": "ProvideCredentials",
+                                        "username": username,
+                                        "password": password
                                     }
                                 }
-                                continue; // Don't forward to event channel
+                            });
+                            // Include sessionId if present
+                            if let Some(ref sid) = session_id {
+                                response["sessionId"] = json!(sid);
                             }
+                            if let Ok(data) = serde_json::to_string(&response) {
+                                let mut w = writer.lock().await;
+                                if let Err(e) = w.send(Message::Text(data)).await {
+                                    tracing::error!(
+                                        "Failed to send proxy auth response: {} — connection may be broken",
+                                        e
+                                    );
+                                    exit_reason = format!("Proxy auth write failed: {}", e);
+                                    // Break so pending requests fail immediately
+                                    // instead of hanging.
+                                    break;
+                                } else {
+                                    tracing::debug!("Auto-responded to proxy auth challenge");
+                                }
+                            }
+                            continue; // Don't forward to event channel
                         }
                     }
-
-                    if event_tx
-                        .try_send(CdpMessage::Event {
-                            method: method.to_string(),
-                            params,
-                            session_id,
-                        })
-                        .is_err()
-                    {
-                        // Channel full or closed — drop event to avoid blocking reader
-                        tracing::trace!("Event channel full, dropping: {}", method);
-                    }
                 }
+
+                // Publish event; ignore "no active receivers" errors.
+                let _ = event_tx.send(CdpMessage::Event {
+                    method: method.to_string(),
+                    params,
+                    session_id,
+                });
             }
         }
 
@@ -649,11 +391,11 @@ impl Transport {
             tracing::warn!("Risky CDP command (may be detectable): {}", method);
         }
 
-        // Check if the reader thread has died (panicked or exited)
+        // Check if the reader task has died (exited)
         if let Some(ref handle) = self.reader_handle {
             if handle.is_finished() {
                 return Err(Error::transport(
-                    "CDP reader thread has exited — WebSocket connection is dead",
+                    "CDP reader task has exited — WebSocket connection is dead",
                 ));
             }
         }
@@ -682,12 +424,12 @@ impl Transport {
 
         // Write to WebSocket — clean up pending entry on failure
         if let Err(e) = {
-            let mut writer = self.writer.lock().unwrap();
-            write_ws_frame(&mut writer, data.as_bytes())
+            let mut writer = self.writer.lock().await;
+            writer.send(Message::Text(data)).await
         } {
             let mut pending = self.pending.lock().unwrap();
             pending.remove(&id);
-            return Err(Error::transport_io("WebSocket write failed", e));
+            return Err(Error::transport(format!("WebSocket write failed: {}", e)));
         }
 
         tracing::trace!("Sent CDP command: {} (id={})", method, id);
@@ -741,25 +483,49 @@ impl Transport {
         self.send_impl(Some(session_id), method, params).await
     }
 
-    /// Receive the next event from Chrome
-    pub async fn recv_event(&self) -> Option<CdpMessage> {
-        let mut rx = self.event_rx.lock().await;
-        rx.recv().await
+    /// Subscribe to CDP events. Each subscriber gets its own receiver; events
+    /// published after subscribing are delivered to all live receivers.
+    pub fn subscribe(&self) -> broadcast::Receiver<CdpMessage> {
+        self.event_tx.subscribe()
     }
 
-    /// Try to receive an event without blocking
+    /// Receive the next event from Chrome (single-consumer back-compat).
+    /// Skips over lagged notifications and returns the next available event.
+    pub async fn recv_event(&self) -> Option<CdpMessage> {
+        let mut rx = self.event_rx.lock().await;
+        loop {
+            match rx.recv().await {
+                Ok(msg) => return Some(msg),
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!("Event receiver lagged, skipped {} event(s)", n);
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+
+    /// Try to receive an event without blocking (single-consumer back-compat).
     pub async fn try_recv_event(&self) -> Option<CdpMessage> {
         let mut rx = self.event_rx.lock().await;
-        rx.try_recv().ok()
+        loop {
+            match rx.try_recv() {
+                Ok(msg) => return Some(msg),
+                Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                    tracing::warn!("Event receiver lagged, skipped {} event(s)", n);
+                    continue;
+                }
+                Err(_) => return None,
+            }
+        }
     }
 
     /// Close the transport and kill Chrome
     pub async fn close(&self) -> Result<()> {
-        // Send WebSocket close frame
+        // Send a WebSocket close frame (best-effort).
         {
-            let mut writer = self.writer.lock().unwrap();
-            let close_frame = vec![0x80 | ws::OPCODE_CLOSE, 0x80, 0, 0, 0, 0];
-            let _ = std::io::Write::write_all(&mut *writer, &close_frame);
+            let mut writer = self.writer.lock().await;
+            let _ = writer.send(Message::Close(None)).await;
         }
 
         if let Some(ref child) = self.child {

--- a/src/cdp/transport.rs
+++ b/src/cdp/transport.rs
@@ -94,13 +94,20 @@ pub struct Transport {
 /// A parsed CDP message (response or event)
 #[derive(Debug, Clone)]
 pub enum CdpMessage {
+    /// Response to a previously issued command.
     Response {
+        /// Command ID this response corresponds to.
         id: u64,
+        /// Command result, or the CDP error it returned.
         result: Result<Value>,
     },
+    /// An event emitted by Chrome.
     Event {
+        /// Event method name (e.g. "Network.requestWillBeSent").
         method: String,
+        /// Event payload.
         params: Value,
+        /// Session ID the event originated from, if any.
         session_id: Option<String>,
     },
 }

--- a/src/cdp/types.rs
+++ b/src/cdp/types.rs
@@ -2,6 +2,12 @@
 //!
 //! These replace the massive chromiumoxide-generated types with a minimal set
 //! that's just enough for stealth browser automation.
+//!
+//! Now that this module is crate-private (no longer re-exported), some fields
+//! are deserialized from CDP responses but never read internally, and a few
+//! protocol structs are only used by escape-hatch wrappers. Allow dead code
+//! rather than prune fields the protocol still sends.
+#![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -215,6 +221,9 @@ pub struct InputDispatchMouseEvent {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+// Variants serialize to the exact CDP event-type strings ("mousePressed", …),
+// so the shared `Mouse` prefix is intentional and must not be renamed.
+#[allow(clippy::enum_variant_names)]
 pub enum MouseEventType {
     MousePressed,
     MouseReleased,

--- a/src/element.rs
+++ b/src/element.rs
@@ -8,13 +8,18 @@ use crate::page::{escape_js_string, sleep_ms, Page, INTERACTION_DELAY_MS};
 /// Bounding box of an element
 #[derive(Debug, Clone, Copy)]
 pub struct BoundingBox {
+    /// X coordinate of the top-left corner, in CSS pixels.
     pub x: f64,
+    /// Y coordinate of the top-left corner, in CSS pixels.
     pub y: f64,
+    /// Width in CSS pixels.
     pub width: f64,
+    /// Height in CSS pixels.
     pub height: f64,
 }
 
 impl BoundingBox {
+    /// Center point of the box as `(x, y)`.
     pub fn center(&self) -> (f64, f64) {
         (self.x + self.width / 2.0, self.y + self.height / 2.0)
     }

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,0 +1,199 @@
+//! Element Abstraction
+//!
+//! DOM element wrapper and its bounding box type. Split out of `page.rs`.
+
+use crate::error::{Error, Result};
+use crate::page::{escape_js_string, sleep_ms, Page, INTERACTION_DELAY_MS};
+
+/// Bounding box of an element
+#[derive(Debug, Clone, Copy)]
+pub struct BoundingBox {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+impl BoundingBox {
+    pub fn center(&self) -> (f64, f64) {
+        (self.x + self.width / 2.0, self.y + self.height / 2.0)
+    }
+}
+
+/// An element on the page (holds a CDP node_id, can become stale on DOM changes)
+pub struct Element<'a> {
+    pub(crate) page: &'a Page,
+    pub(crate) node_id: i32,
+}
+
+impl<'a> Element<'a> {
+    /// Get the element's center coordinates
+    pub async fn center(&self) -> Result<(f64, f64)> {
+        let model = self.page.session.get_box_model(self.node_id).await?;
+        model.try_center().ok_or_else(|| Error::ElementNotVisible {
+            selector: format!("node {}", self.node_id),
+        })
+    }
+
+    /// Click this element
+    pub async fn click(&self) -> Result<()> {
+        let (x, y) = self.center().await?;
+        self.page.click_at(x, y).await
+    }
+
+    /// Human-like click
+    pub async fn human_click(&self) -> Result<()> {
+        let (x, y) = self.center().await?;
+        self.page.human().move_and_click(x, y).await
+    }
+
+    /// Get outer HTML
+    pub async fn outer_html(&self) -> Result<String> {
+        self.page.session.get_outer_html(self.node_id).await
+    }
+
+    /// Get inner text
+    ///
+    /// Extracts text content from the element's outerHTML without using focus.
+    pub async fn text(&self) -> Result<String> {
+        self.eval_str("this.textContent || ''").await
+    }
+
+    /// Evaluate a JavaScript expression on this element via Runtime.callFunctionOn.
+    ///
+    /// The expression should use `this` to refer to the element.
+    /// Example: `"this.textContent || ''"`, `"this.tagName.toLowerCase()"`
+    async fn eval_on_element(&self, js_body: &str) -> Result<serde_json::Value> {
+        let object_id = self.page.session.resolve_node(self.node_id).await?;
+        let func = format!("function() {{ return {}; }}", js_body);
+        let result = self
+            .page
+            .session
+            .call_function_on(&object_id, &func)
+            .await?;
+        Ok(result.result.value.unwrap_or(serde_json::Value::Null))
+    }
+
+    /// Evaluate JS on element, return as String (empty string on null/non-string)
+    async fn eval_str(&self, js_body: &str) -> Result<String> {
+        let value = self.eval_on_element(js_body).await?;
+        Ok(value.as_str().unwrap_or("").to_string())
+    }
+
+    /// Evaluate JS on element, return as bool with a default
+    async fn eval_bool(&self, js_body: &str, default: bool) -> Result<bool> {
+        let value = self.eval_on_element(js_body).await?;
+        Ok(value.as_bool().unwrap_or(default))
+    }
+
+    /// Type text into this element
+    pub async fn type_text(&self, text: &str) -> Result<()> {
+        self.click().await?;
+        sleep_ms(INTERACTION_DELAY_MS).await;
+        self.page.session.insert_text(text).await
+    }
+
+    /// Focus this element
+    pub async fn focus(&self) -> Result<()> {
+        self.page.session.focus(self.node_id).await
+    }
+    /// Check if the element is visible (has a computable box model)
+    pub async fn is_visible(&self) -> Result<bool> {
+        match self.page.session.get_box_model(self.node_id).await {
+            Ok(_) => Ok(true),
+            Err(Error::Cdp { message, .. }) if message.contains("box model") => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Get the element's bounding box
+    ///
+    /// Returns None if the element is not visible/rendered.
+    pub async fn bounding_box(&self) -> Option<BoundingBox> {
+        match self.page.session.get_box_model(self.node_id).await {
+            Ok(model) => {
+                let content = &model.content;
+                if content.len() >= 8 {
+                    // content is [x1,y1, x2,y2, x3,y3, x4,y4] for a quad
+                    // Handle rotated/transformed elements by finding actual bounds
+                    let xs = [content[0], content[2], content[4], content[6]];
+                    let ys = [content[1], content[3], content[5], content[7]];
+
+                    let min_x = xs.iter().copied().fold(f64::INFINITY, f64::min);
+                    let max_x = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                    let min_y = ys.iter().copied().fold(f64::INFINITY, f64::min);
+                    let max_y = ys.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+
+                    Some(BoundingBox {
+                        x: min_x,
+                        y: min_y,
+                        width: max_x - min_x,
+                        height: max_y - min_y,
+                    })
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Get an attribute value
+    pub async fn get_attribute(&self, name: &str) -> Result<Option<String>> {
+        let escaped_name = escape_js_string(name);
+        let value = self
+            .eval_on_element(&format!("this.getAttribute('{}')", escaped_name))
+            .await?;
+
+        if value.is_null() {
+            return Ok(None);
+        }
+        if let Some(s) = value.as_str() {
+            return Ok(Some(s.to_string()));
+        }
+        Ok(None)
+    }
+
+    /// Get the tag name of the element (e.g., "div", "input", "a")
+    pub async fn tag_name(&self) -> Result<String> {
+        self.eval_str("this.tagName.toLowerCase()").await
+    }
+
+    /// Check if the element is enabled (not disabled)
+    pub async fn is_enabled(&self) -> Result<bool> {
+        self.eval_bool("!this.disabled", true).await
+    }
+
+    /// Check if a checkbox/radio is checked
+    pub async fn is_checked(&self) -> Result<bool> {
+        self.eval_bool("this.checked === true", false).await
+    }
+
+    /// Get the value of an input element
+    pub async fn value(&self) -> Result<String> {
+        self.eval_str("this.value || ''").await
+    }
+
+    /// Get computed CSS property value
+    pub async fn css(&self, property: &str) -> Result<String> {
+        let escaped = escape_js_string(property);
+        self.eval_str(&format!(
+            "getComputedStyle(this).getPropertyValue('{}')",
+            escaped
+        ))
+        .await
+    }
+
+    /// Scroll this element into view
+    pub async fn scroll_into_view(&self) -> Result<()> {
+        let object_id = self.page.session.resolve_node(self.node_id).await?;
+        self.page
+            .session
+            .call_function_on(
+                &object_id,
+                "function() { this.scrollIntoView({ behavior: 'smooth', block: 'center' }); }",
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/src/element.rs
+++ b/src/element.rs
@@ -20,13 +20,16 @@ impl BoundingBox {
     }
 }
 
-/// An element on the page (holds a CDP node_id, can become stale on DOM changes)
-pub struct Element<'a> {
-    pub(crate) page: &'a Page,
+/// A handle to a DOM element. Owns a cheap clone of its `Page`, so it is
+/// `'static` — you can store it, return it, and pass it around freely. The
+/// `node_id` can still go stale if the DOM mutates or the page navigates; a
+/// stale handle surfaces as an `ElementNotFound`/`Cdp` error on use.
+pub struct Element {
+    pub(crate) page: Page,
     pub(crate) node_id: i32,
 }
 
-impl<'a> Element<'a> {
+impl Element {
     /// Get the element's center coordinates
     pub async fn center(&self) -> Result<(f64, f64)> {
         let model = self.page.session.get_box_model(self.node_id).await?;
@@ -195,5 +198,18 @@ impl<'a> Element<'a> {
             )
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Element;
+
+    // Element owns its Page, so it must be Send + 'static — storable, returnable,
+    // and movable across await points and tasks. This is the reusability contract.
+    #[test]
+    fn element_is_send_and_static() {
+        fn assert_send_static<T: Send + 'static>() {}
+        assert_send_static::<Element>();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,54 @@ pub enum Error {
     RetryExhausted { attempts: u32, last_error: String },
 }
 
+// `std::io::Error` and `serde_json::Error` aren't `Clone`, so we can't derive it.
+// Reconstruct both best-effort (kind + message) so `Error` — and thus the
+// broadcast `CdpMessage` — is cloneable.
+impl Clone for Error {
+    fn clone(&self) -> Self {
+        use serde::de::Error as _;
+        match self {
+            Self::Launch(s) => Self::Launch(s.clone()),
+            Self::Transport { context, source } => Self::Transport {
+                context: context.clone(),
+                source: source
+                    .as_ref()
+                    .map(|e| std::io::Error::new(e.kind(), e.to_string())),
+            },
+            Self::Cdp {
+                method,
+                code,
+                message,
+            } => Self::Cdp {
+                method: method.clone(),
+                code: *code,
+                message: message.clone(),
+            },
+            Self::Navigation(s) => Self::Navigation(s.clone()),
+            Self::ElementNotFound(s) => Self::ElementNotFound(s.clone()),
+            Self::ElementNotVisible { selector } => Self::ElementNotVisible {
+                selector: selector.clone(),
+            },
+            Self::Timeout(s) => Self::Timeout(s.clone()),
+            Self::Serialization(e) => Self::Serialization(serde_json::Error::custom(e.to_string())),
+            Self::Decode(s) => Self::Decode(s.clone()),
+            Self::Io(e) => Self::Io(std::io::Error::new(e.kind(), e.to_string())),
+            Self::ChromeNotFound => Self::ChromeNotFound,
+            Self::Patching { operation, message } => Self::Patching {
+                operation: operation.clone(),
+                message: message.clone(),
+            },
+            Self::RetryExhausted {
+                attempts,
+                last_error,
+            } => Self::RetryExhausted {
+                attempts: *attempts,
+                last_error: last_error.clone(),
+            },
+        }
+    }
+}
+
 /// Display for the `Cdp` variant, including method/code context when present.
 fn cdp_fmt(
     method: &Option<String>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,11 @@ use thiserror::Error;
 /// Result type for eoka operations
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Error type for eoka
+/// Error type for eoka.
+///
+/// `#[non_exhaustive]`: match with a `_ =>` arm so new variants are additive.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Failed to launch Chrome
     #[error("Failed to launch Chrome: {0}")]
@@ -20,17 +23,14 @@ pub enum Error {
         source: Option<std::io::Error>,
     },
 
-    /// CDP protocol error
-    #[error("CDP error in {method}: {message} (code {code})")]
+    /// CDP protocol error. `method`/`code` carry command context when the error
+    /// came from a command response, and are `None` for context-free failures.
+    #[error(fmt = cdp_fmt)]
     Cdp {
-        method: String,
-        code: i64,
+        method: Option<String>,
+        code: Option<i64>,
         message: String,
     },
-
-    /// CDP error without method context (for simple cases)
-    #[error("CDP error: {0}")]
-    CdpSimple(String),
 
     /// Navigation error
     #[error("Navigation error: {0}")]
@@ -73,6 +73,20 @@ pub enum Error {
     RetryExhausted { attempts: u32, last_error: String },
 }
 
+/// Display for the `Cdp` variant, including method/code context when present.
+fn cdp_fmt(
+    method: &Option<String>,
+    code: &Option<i64>,
+    message: &str,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    match (method, code) {
+        (Some(m), Some(c)) => write!(f, "CDP error in {}: {} (code {})", m, message, c),
+        (Some(m), None) => write!(f, "CDP error in {}: {}", m, message),
+        _ => write!(f, "CDP error: {}", message),
+    }
+}
+
 /// Display for the `Transport` variant, including the io error cause when present.
 fn transport_fmt(
     context: &str,
@@ -102,11 +116,20 @@ impl Error {
         }
     }
 
-    /// Create a CDP error with full context
+    /// Create a CDP error with full command context.
     pub fn cdp(method: impl Into<String>, code: i64, message: impl Into<String>) -> Self {
         Self::Cdp {
-            method: method.into(),
-            code,
+            method: Some(method.into()),
+            code: Some(code),
+            message: message.into(),
+        }
+    }
+
+    /// Create a CDP error without command context.
+    pub fn cdp_msg(message: impl Into<String>) -> Self {
+        Self::Cdp {
+            method: None,
+            code: None,
             message: message.into(),
         }
     }
@@ -150,6 +173,17 @@ mod tests {
             err.source().is_some(),
             "transport_io error should expose its io source"
         );
+    }
+
+    #[test]
+    fn test_cdp_display_with_and_without_context() {
+        let full = Error::cdp("DOM.resolveNode", -1, "boom");
+        assert_eq!(
+            format!("{full}"),
+            "CDP error in DOM.resolveNode: boom (code -1)"
+        );
+        let simple = Error::cdp_msg("no value");
+        assert_eq!(format!("{simple}"), "CDP error: no value");
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,9 @@ pub enum Error {
     /// Transport error
     #[error(fmt = transport_fmt)]
     Transport {
+        /// Description of what failed.
         context: String,
+        /// Underlying IO error, if any.
         #[source]
         source: Option<std::io::Error>,
     },
@@ -27,8 +29,11 @@ pub enum Error {
     /// came from a command response, and are `None` for context-free failures.
     #[error(fmt = cdp_fmt)]
     Cdp {
+        /// CDP command method that failed, if known.
         method: Option<String>,
+        /// CDP error code, if known.
         code: Option<i64>,
+        /// Error message.
         message: String,
     },
 
@@ -42,7 +47,10 @@ pub enum Error {
 
     /// Element exists in DOM but is not visible/rendered
     #[error("Element not visible: '{selector}' exists in DOM but is not rendered (hidden, display:none, or off-screen)")]
-    ElementNotVisible { selector: String },
+    ElementNotVisible {
+        /// Selector that matched the hidden element.
+        selector: String,
+    },
 
     /// Timeout
     #[error("Timeout: {0}")]
@@ -66,11 +74,21 @@ pub enum Error {
 
     /// Binary patching error
     #[error("Patching error in {operation}: {message}")]
-    Patching { operation: String, message: String },
+    Patching {
+        /// Patching operation that failed.
+        operation: String,
+        /// Error message.
+        message: String,
+    },
 
     /// Retry exhausted
     #[error("Retry exhausted after {attempts} attempts: {last_error}")]
-    RetryExhausted { attempts: u32, last_error: String },
+    RetryExhausted {
+        /// Number of attempts made before giving up.
+        attempts: u32,
+        /// The last error encountered.
+        last_error: String,
+    },
 }
 
 // `std::io::Error` and `serde_json::Error` aren't `Clone`, so we can't derive it.

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,0 +1,219 @@
+//! Keyboard key parsing
+//!
+//! Combo parsing and key-to-code lookup used by `Page::press_key`. Split out of `page.rs`.
+
+pub(crate) fn parse_key_combo(combo: &str) -> (i32, &str) {
+    use crate::cdp::types::modifiers;
+    let parts: Vec<&str> = combo.split('+').collect();
+    let mut mods = 0;
+    let mut key = combo;
+    for (i, part) in parts.iter().enumerate() {
+        match part.to_lowercase().as_str() {
+            "ctrl" | "control" => mods |= modifiers::CTRL,
+            "alt" | "option" => mods |= modifiers::ALT,
+            "shift" => mods |= modifiers::SHIFT,
+            "cmd" | "meta" | "command" => mods |= modifiers::META,
+            _ => key = parts[i],
+        }
+    }
+    if key.is_empty() {
+        key = "+";
+    }
+    (mods, key)
+}
+
+pub(crate) fn key_to_codes(key: &str) -> (&str, &str, Option<i32>) {
+    static KEYS: &[(&str, &str, &str, i32)] = &[
+        ("enter", "Enter", "Enter", 13),
+        ("return", "Enter", "Enter", 13),
+        ("tab", "Tab", "Tab", 9),
+        ("escape", "Escape", "Escape", 27),
+        ("esc", "Escape", "Escape", 27),
+        ("backspace", "Backspace", "Backspace", 8),
+        ("delete", "Delete", "Delete", 46),
+        ("arrowup", "ArrowUp", "ArrowUp", 38),
+        ("up", "ArrowUp", "ArrowUp", 38),
+        ("arrowdown", "ArrowDown", "ArrowDown", 40),
+        ("down", "ArrowDown", "ArrowDown", 40),
+        ("arrowleft", "ArrowLeft", "ArrowLeft", 37),
+        ("left", "ArrowLeft", "ArrowLeft", 37),
+        ("arrowright", "ArrowRight", "ArrowRight", 39),
+        ("right", "ArrowRight", "ArrowRight", 39),
+        ("home", "Home", "Home", 36),
+        ("end", "End", "End", 35),
+        ("pageup", "PageUp", "PageUp", 33),
+        ("pagedown", "PageDown", "PageDown", 34),
+        ("space", " ", "Space", 32),
+        ("a", "a", "KeyA", 65),
+        ("b", "b", "KeyB", 66),
+        ("c", "c", "KeyC", 67),
+        ("d", "d", "KeyD", 68),
+        ("e", "e", "KeyE", 69),
+        ("f", "f", "KeyF", 70),
+        ("g", "g", "KeyG", 71),
+        ("h", "h", "KeyH", 72),
+        ("i", "i", "KeyI", 73),
+        ("j", "j", "KeyJ", 74),
+        ("k", "k", "KeyK", 75),
+        ("l", "l", "KeyL", 76),
+        ("m", "m", "KeyM", 77),
+        ("n", "n", "KeyN", 78),
+        ("o", "o", "KeyO", 79),
+        ("p", "p", "KeyP", 80),
+        ("q", "q", "KeyQ", 81),
+        ("r", "r", "KeyR", 82),
+        ("s", "s", "KeyS", 83),
+        ("t", "t", "KeyT", 84),
+        ("u", "u", "KeyU", 85),
+        ("v", "v", "KeyV", 86),
+        ("w", "w", "KeyW", 87),
+        ("x", "x", "KeyX", 88),
+        ("y", "y", "KeyY", 89),
+        ("z", "z", "KeyZ", 90),
+        ("f1", "F1", "F1", 112),
+        ("f2", "F2", "F2", 113),
+        ("f3", "F3", "F3", 114),
+        ("f4", "F4", "F4", 115),
+        ("f5", "F5", "F5", 116),
+        ("f6", "F6", "F6", 117),
+        ("f7", "F7", "F7", 118),
+        ("f8", "F8", "F8", 119),
+        ("f9", "F9", "F9", 120),
+        ("f10", "F10", "F10", 121),
+        ("f11", "F11", "F11", 122),
+        ("f12", "F12", "F12", 123),
+    ];
+    let lower = key.to_lowercase();
+    KEYS.iter()
+        .find(|(name, _, _, _)| *name == lower)
+        .map(|(_, k, c, vk)| (*k, *c, Some(*vk)))
+        .unwrap_or((key, key, None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_key_combo_simple() {
+        let (mods, key) = parse_key_combo("Enter");
+        assert_eq!(mods, 0);
+        assert_eq!(key, "Enter");
+    }
+
+    #[test]
+    fn test_parse_key_combo_ctrl() {
+        use crate::cdp::types::modifiers;
+        let (mods, key) = parse_key_combo("Ctrl+A");
+        assert_eq!(mods, modifiers::CTRL);
+        assert_eq!(key, "A");
+    }
+
+    #[test]
+    fn test_parse_key_combo_cmd_shift() {
+        use crate::cdp::types::modifiers;
+        let (mods, key) = parse_key_combo("Cmd+Shift+S");
+        assert_eq!(mods, modifiers::META | modifiers::SHIFT);
+        assert_eq!(key, "S");
+    }
+
+    #[test]
+    fn test_parse_key_combo_all_modifiers() {
+        use crate::cdp::types::modifiers;
+        let (mods, key) = parse_key_combo("Ctrl+Alt+Shift+Cmd+X");
+        assert_eq!(
+            mods,
+            modifiers::CTRL | modifiers::ALT | modifiers::SHIFT | modifiers::META
+        );
+        assert_eq!(key, "X");
+    }
+
+    #[test]
+    fn test_parse_key_combo_case_insensitive() {
+        use crate::cdp::types::modifiers;
+        let (mods, key) = parse_key_combo("ctrl+a");
+        assert_eq!(mods, modifiers::CTRL);
+        assert_eq!(key, "a");
+    }
+
+    #[test]
+    fn test_key_to_codes_enter() {
+        let (key, code, vk) = key_to_codes("Enter");
+        assert_eq!(key, "Enter");
+        assert_eq!(code, "Enter");
+        assert_eq!(vk, Some(13));
+    }
+
+    #[test]
+    fn test_key_to_codes_tab() {
+        let (key, code, vk) = key_to_codes("Tab");
+        assert_eq!(key, "Tab");
+        assert_eq!(code, "Tab");
+        assert_eq!(vk, Some(9));
+    }
+
+    #[test]
+    fn test_key_to_codes_letter() {
+        let (key, code, vk) = key_to_codes("a");
+        assert_eq!(key, "a");
+        assert_eq!(code, "KeyA");
+        assert_eq!(vk, Some(65));
+    }
+
+    #[test]
+    fn test_key_to_codes_arrow() {
+        let (key, code, vk) = key_to_codes("ArrowDown");
+        assert_eq!(key, "ArrowDown");
+        assert_eq!(code, "ArrowDown");
+        assert_eq!(vk, Some(40));
+    }
+
+    #[test]
+    fn test_key_to_codes_case_insensitive() {
+        let (key, code, vk) = key_to_codes("ESCAPE");
+        assert_eq!(key, "Escape");
+        assert_eq!(code, "Escape");
+        assert_eq!(vk, Some(27));
+    }
+
+    #[test]
+    fn test_key_to_codes_alias() {
+        // "esc" should work as alias for "Escape"
+        let (key, code, vk) = key_to_codes("esc");
+        assert_eq!(key, "Escape");
+        assert_eq!(code, "Escape");
+        assert_eq!(vk, Some(27));
+
+        // "up" should work as alias for "ArrowUp"
+        let (key, code, vk) = key_to_codes("up");
+        assert_eq!(key, "ArrowUp");
+        assert_eq!(code, "ArrowUp");
+        assert_eq!(vk, Some(38));
+    }
+
+    #[test]
+    fn test_key_to_codes_unknown() {
+        // Unknown keys should pass through
+        let (key, code, vk) = key_to_codes("SomeWeirdKey");
+        assert_eq!(key, "SomeWeirdKey");
+        assert_eq!(code, "SomeWeirdKey");
+        assert_eq!(vk, None);
+    }
+
+    #[test]
+    fn test_parse_key_combo_literal_plus() {
+        // A lone "+" is a literal key, not a separator artifact.
+        let (mods, key) = parse_key_combo("+");
+        assert_eq!(mods, 0);
+        assert_eq!(key, "+");
+    }
+
+    #[test]
+    fn test_parse_key_combo_shift_plus() {
+        // "Shift++" is SHIFT modifier plus the literal "+" key.
+        use crate::cdp::types::modifiers;
+        let (mods, key) = parse_key_combo("Shift++");
+        assert_eq!(mods, modifiers::SHIFT);
+        assert_eq!(key, "+");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! - **Stealth by Default** - Binary patching, 15 JS evasions, human-like mouse/typing
 //! - **Puppeteer-like API** - `click()`, `type()`, `wait_for()`, `screenshot()`, etc.
-//! - **Minimal Dependencies** - ~10 crates total, no chromiumoxide bloat
+//! - **Minimal Dependencies** - 11 direct crates, no chromiumoxide/puppeteer-extra bloat
 //! - **AI-Agent Ready** - PageState introspection, element indexing, text extraction
 //! - **Fast** - Lazy evasion scripts, mmap patching, stack-allocated paths
 //!
@@ -59,6 +59,8 @@
 //! # Ok(())
 //! # }
 //! ```
+
+#![deny(missing_docs)]
 
 pub mod browser;
 pub mod cdp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,9 @@
 
 pub mod browser;
 pub mod cdp;
+pub mod element;
 pub mod error;
+pub mod keyboard;
 pub mod network;
 pub mod page;
 pub mod session;
@@ -80,11 +82,10 @@ const _: () = {
 
 // Re-exports
 pub use browser::{Browser, TabInfo};
+pub use element::{BoundingBox, Element};
 pub use error::{Error, Result};
 pub use network::{NetworkEvent, NetworkWatcher};
-pub use page::{
-    BoundingBox, CapturedRequest, Element, FrameInfo, Page, PageState, ResponseBody, TextMatch,
-};
+pub use page::{CapturedRequest, FrameInfo, Page, PageState, ResponseBody, TextMatch};
 pub use session::{BrowserSession, SessionCookie};
 pub use stealth::{Fingerprint, HumanSpeed};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,19 +43,19 @@
 //! ## Configuration
 //!
 //! ```rust,no_run
-//! use eoka::{Browser, StealthConfig};
+//! use eoka::Browser;
 //!
 //! # #[tokio::main]
 //! # async fn main() -> eoka::Result<()> {
-//! let config = StealthConfig {
-//!     headless: true,
-//!     patch_binary: true,
-//!     webgl_spoof: true,
-//!     canvas_spoof: true,
-//!     ..Default::default()
-//! };
+//! // The default launch path is stealthy and headless.
+//! let browser = Browser::launch().await?;
+//! browser.close().await?;
 //!
-//! let browser = Browser::launch_with_config(config).await?;
+//! // For one-off tweaks, mutate the default stealth config inline.
+//! let browser = Browser::launch_with(|config| {
+//!     config.proxy = Some("http://127.0.0.1:8080".into());
+//! }).await?;
+//! browser.close().await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -66,7 +66,7 @@ pub mod browser;
 pub mod cdp;
 pub mod element;
 pub mod error;
-pub mod keyboard;
+mod keyboard;
 pub mod network;
 pub mod page;
 pub mod session;
@@ -222,5 +222,21 @@ impl StealthConfig {
             human_typing: true,
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StealthConfig;
+
+    #[test]
+    fn default_config_is_headless() {
+        assert!(StealthConfig::default().headless);
+    }
+
+    #[test]
+    fn visible_configs_are_explicitly_not_headless() {
+        assert!(!StealthConfig::visible().headless);
+        assert!(!StealthConfig::debug().headless);
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -21,21 +21,31 @@ pub enum NetworkEvent {
     RequestStarted(CapturedRequest),
     /// Response headers received
     ResponseReceived {
+        /// ID of the request this response belongs to.
         request_id: String,
+        /// HTTP status code.
         status: i32,
+        /// HTTP status text.
         status_text: String,
+        /// Response headers.
         headers: HashMap<String, String>,
+        /// Response MIME type, if known.
         mime_type: Option<String>,
     },
     /// Request completed successfully
     RequestCompleted {
+        /// ID of the completed request.
         request_id: String,
+        /// Total bytes received over the wire.
         encoded_data_length: i64,
     },
     /// Request failed
     RequestFailed {
+        /// ID of the failed request.
         request_id: String,
+        /// Failure reason.
         error_text: String,
+        /// Whether the request was canceled.
         canceled: bool,
     },
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -91,12 +91,15 @@ pub enum TextMatch {
     EndsWith,
 }
 
-/// A browser page with stealth capabilities
+/// A browser page with stealth capabilities. Cheap to clone (`Arc`-backed
+/// shared state) — clones refer to the same tab and share the document cache.
+#[derive(Clone)]
 pub struct Page {
     pub(crate) session: Session,
     config: Arc<StealthConfig>,
     /// Cached root `DOM.getDocument` node id (invalidated on navigation).
-    root_node: std::sync::Mutex<Option<i32>>,
+    /// `Arc` so `Element` clones share one page's cache.
+    root_node: Arc<std::sync::Mutex<Option<i32>>>,
     /// Randomized per-page property key for the network-idle request counter.
     net_idle_key: String,
 }
@@ -108,7 +111,7 @@ impl Page {
         Self {
             session,
             config,
-            root_node: std::sync::Mutex::new(None),
+            root_node: Arc::new(std::sync::Mutex::new(None)),
             net_idle_key,
         }
     }
@@ -236,7 +239,7 @@ impl Page {
             .await
     }
     /// Find an element by CSS selector
-    pub async fn find(&self, selector: &str) -> Result<Element<'_>> {
+    pub async fn find(&self, selector: &str) -> Result<Element> {
         let node_id = self
             .with_document(|doc| self.session.query_selector(doc, selector))
             .await?;
@@ -246,13 +249,13 @@ impl Page {
         }
 
         Ok(Element {
-            page: self,
+            page: self.clone(),
             node_id,
         })
     }
 
     /// Find all elements matching a CSS selector
-    pub async fn find_all(&self, selector: &str) -> Result<Vec<Element<'_>>> {
+    pub async fn find_all(&self, selector: &str) -> Result<Vec<Element>> {
         let node_ids = self
             .with_document(|doc| self.session.query_selector_all(doc, selector))
             .await?;
@@ -261,7 +264,7 @@ impl Page {
             .into_iter()
             .filter(|&id| id != 0)
             .map(|node_id| Element {
-                page: self,
+                page: self.clone(),
                 node_id,
             })
             .collect())
@@ -273,7 +276,7 @@ impl Page {
         self.find(selector).await.is_ok()
     }
     /// Find an element by its text content (case-insensitive contains)
-    pub async fn find_by_text(&self, text: &str) -> Result<Element<'_>> {
+    pub async fn find_by_text(&self, text: &str) -> Result<Element> {
         self.find_by_text_match(text, TextMatch::Contains).await
     }
 
@@ -281,11 +284,7 @@ impl Page {
     ///
     /// Prioritizes interactive elements (a, button, input) over static elements.
     /// Uses Runtime.callFunctionOn to avoid mutating the DOM (no marker attributes).
-    pub async fn find_by_text_match(
-        &self,
-        text: &str,
-        match_type: TextMatch,
-    ) -> Result<Element<'_>> {
+    pub async fn find_by_text_match(&self, text: &str, match_type: TextMatch) -> Result<Element> {
         let escaped_text = escape_js_string(text);
         let match_js = match match_type {
             TextMatch::Exact => format!("t.trim() === '{}'", escaped_text),
@@ -344,13 +343,13 @@ impl Page {
         }
 
         Ok(Element {
-            page: self,
+            page: self.clone(),
             node_id,
         })
     }
 
     /// Find all elements matching the given text
-    pub async fn find_all_by_text(&self, text: &str) -> Result<Vec<Element<'_>>> {
+    pub async fn find_all_by_text(&self, text: &str) -> Result<Vec<Element>> {
         let escaped_text = escape_js_string(text).to_lowercase();
 
         let js = format!(
@@ -396,7 +395,7 @@ impl Page {
                 if let Ok(node_id) = self.session.request_node(obj_id).await {
                     if node_id != 0 {
                         elements.push(Element {
-                            page: self,
+                            page: self.clone(),
                             node_id,
                         });
                     }
@@ -479,7 +478,7 @@ impl Page {
     }
 
     /// Shared impl for try_click and try_click_by_text
-    async fn try_click_impl(&self, find_result: Result<Element<'_>>) -> Result<bool> {
+    async fn try_click_impl(&self, find_result: Result<Element>) -> Result<bool> {
         match find_result {
             Ok(element) => match element.click().await {
                 Ok(()) => Ok(true),
@@ -579,7 +578,7 @@ impl Page {
     }
 
     /// Shared impl for try_human_click and try_human_click_by_text
-    async fn try_human_click_impl(&self, find_result: Result<Element<'_>>) -> Result<bool> {
+    async fn try_human_click_impl(&self, find_result: Result<Element>) -> Result<bool> {
         match find_result {
             Ok(element) => match element.center().await {
                 Ok((x, y)) => {
@@ -796,7 +795,7 @@ impl Page {
     }
 
     /// Wait for an element to appear in the DOM
-    pub async fn wait_for(&self, selector: &str, timeout_ms: u64) -> Result<Element<'_>> {
+    pub async fn wait_for(&self, selector: &str, timeout_ms: u64) -> Result<Element> {
         self.poll_until(
             timeout_ms,
             format!("Element '{}' not found within {}ms", selector, timeout_ms),
@@ -806,7 +805,7 @@ impl Page {
     }
 
     /// Wait for an element to be visible and clickable
-    pub async fn wait_for_visible(&self, selector: &str, timeout_ms: u64) -> Result<Element<'_>> {
+    pub async fn wait_for_visible(&self, selector: &str, timeout_ms: u64) -> Result<Element> {
         self.poll_until(
             timeout_ms,
             format!("Element '{}' not visible within {}ms", selector, timeout_ms),
@@ -850,7 +849,7 @@ impl Page {
     }
 
     /// Wait for an element with specific text to appear
-    pub async fn wait_for_text(&self, text: &str, timeout_ms: u64) -> Result<Element<'_>> {
+    pub async fn wait_for_text(&self, text: &str, timeout_ms: u64) -> Result<Element> {
         self.poll_until(
             timeout_ms,
             format!(
@@ -926,7 +925,7 @@ impl Page {
         }
     }
     /// Find the first element matching any of the given selectors
-    pub async fn find_any(&self, selectors: &[&str]) -> Result<Element<'_>> {
+    pub async fn find_any(&self, selectors: &[&str]) -> Result<Element> {
         for selector in selectors {
             if let Ok(element) = self.find(selector).await {
                 return Ok(element);
@@ -941,7 +940,7 @@ impl Page {
     /// Wait for any of the given selectors to appear
     ///
     /// Returns the first selector that matches.
-    pub async fn wait_for_any(&self, selectors: &[&str], timeout_ms: u64) -> Result<Element<'_>> {
+    pub async fn wait_for_any(&self, selectors: &[&str], timeout_ms: u64) -> Result<Element> {
         self.poll_until(
             timeout_ms,
             format!(

--- a/src/page.rs
+++ b/src/page.rs
@@ -608,7 +608,7 @@ impl Page {
         let remote = self.check_js_result(result)?;
         let value = remote
             .value
-            .ok_or_else(|| Error::CdpSimple("No value returned from evaluate".into()))?;
+            .ok_or_else(|| Error::cdp_msg("No value returned from evaluate"))?;
         Ok(serde_json::from_value(value)?)
     }
 
@@ -630,7 +630,7 @@ impl Page {
         result: crate::cdp::types::RuntimeEvaluateResult,
     ) -> Result<crate::cdp::types::RemoteObject> {
         if let Some(exception) = result.exception_details {
-            return Err(Error::CdpSimple(format!(
+            return Err(Error::cdp_msg(format!(
                 "JavaScript error: {} at {}:{}",
                 exception.text, exception.line_number, exception.column_number
             )));
@@ -656,7 +656,7 @@ impl Page {
             .set_cookie(name, value, url.as_deref(), domain, path)
             .await?;
         if !success {
-            return Err(Error::CdpSimple("Failed to set cookie".into()));
+            return Err(Error::cdp_msg("Failed to set cookie"));
         }
         Ok(())
     }
@@ -1378,22 +1378,18 @@ mod tests {
 
     #[test]
     fn test_stale_node_error_detection() {
-        let stale = Error::Cdp {
-            method: "DOM.resolveNode".to_string(),
-            code: -32000,
-            message: "Could not find node with given id".to_string(),
-        };
+        let stale = Error::cdp(
+            "DOM.resolveNode",
+            -32000,
+            "Could not find node with given id",
+        );
         assert!(is_stale_node_error(&stale));
         assert!(is_element_cdp_error(&stale));
     }
 
     #[test]
     fn test_box_model_error_is_element_but_not_stale() {
-        let box_model = Error::Cdp {
-            method: "DOM.getBoxModel".to_string(),
-            code: -32000,
-            message: "box model could not be computed".to_string(),
-        };
+        let box_model = Error::cdp("DOM.getBoxModel", -32000, "box model could not be computed");
         // "box model" substring makes it an element error...
         assert!(is_element_cdp_error(&box_model));
         // ...but it is not a stale-node error.

--- a/src/page.rs
+++ b/src/page.rs
@@ -1304,24 +1304,38 @@ impl Page {
 /// A captured HTTP request with its response
 #[derive(Debug, Clone)]
 pub struct CapturedRequest {
+    /// CDP request ID (use with `get_response_body`).
     pub request_id: String,
+    /// Request URL.
     pub url: String,
+    /// HTTP method.
     pub method: String,
+    /// Request headers.
     pub headers: HashMap<String, String>,
+    /// Request body, if present.
     pub post_data: Option<String>,
+    /// Resource type (e.g. "Document", "XHR", "Script").
     pub resource_type: Option<String>,
+    /// Response status code, once received.
     pub status: Option<i32>,
+    /// Response status text, once received.
     pub status_text: Option<String>,
+    /// Response headers, once received.
     pub response_headers: Option<HashMap<String, String>>,
+    /// Response MIME type, once received.
     pub mime_type: Option<String>,
+    /// Time the request was initiated (CDP monotonic timestamp).
     pub timestamp: f64,
+    /// Whether the response has finished loading.
     pub complete: bool,
 }
 
 /// Response body - either text or binary
 #[derive(Debug)]
 pub enum ResponseBody {
+    /// Textual response body.
     Text(String),
+    /// Binary response body.
     Binary(Vec<u8>),
 }
 
@@ -1357,11 +1371,17 @@ pub struct FrameInfo {
 /// Debug information about page state
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct PageState {
+    /// Current page URL.
     pub url: String,
+    /// Current page title.
     pub title: String,
+    /// Number of `<input>` elements.
     pub input_count: u32,
+    /// Number of `<button>` elements.
     pub button_count: u32,
+    /// Number of `<a>` link elements.
     pub link_count: u32,
+    /// Number of `<form>` elements.
     pub form_count: u32,
 }
 

--- a/src/page.rs
+++ b/src/page.rs
@@ -332,6 +332,10 @@ impl Page {
             .object_id
             .ok_or_else(|| Error::ElementNotFound(format!("text: {}", text)))?;
 
+        // Prime the DOM node-id space (DOM.requestNode returns 0 unless
+        // DOM.getDocument has populated it for the current document).
+        self.document_node().await?;
+
         // Convert remote object to DOM node_id
         let node_id = self.session.request_node(&object_id).await?;
 
@@ -378,6 +382,9 @@ impl Page {
 
         // Get all indexed properties of the array in one CDP call
         let properties = self.session.get_properties(&array_object_id).await?;
+
+        // Prime the DOM node-id space (DOM.requestNode returns 0 otherwise).
+        self.document_node().await?;
 
         let mut elements = Vec::new();
         for prop in &properties {

--- a/src/page.rs
+++ b/src/page.rs
@@ -7,8 +7,13 @@ use std::sync::Arc;
 
 use crate::cdp::{Cookie, MouseButton, MouseEventType, Session};
 use crate::error::{Error, Result};
+use crate::keyboard::{key_to_codes, parse_key_combo};
 use crate::stealth::Human;
 use crate::StealthConfig;
+
+// Re-export so the historical `eoka::page::Element` / `eoka::page::BoundingBox`
+// paths keep resolving after the split into `element.rs`.
+pub use crate::element::{BoundingBox, Element};
 
 /// Polling interval (ms) used by wait_for_* loop iterations.
 const POLL_INTERVAL_MS: u64 = 100;
@@ -18,10 +23,10 @@ const POLL_INTERVAL_MS: u64 = 100;
 const SETTLE_MS: u64 = 100;
 
 /// Brief pause (ms) between micro-interactions (e.g. focus→type, select_all→delete).
-const INTERACTION_DELAY_MS: u64 = 50;
+pub(crate) const INTERACTION_DELAY_MS: u64 = 50;
 
 /// Async sleep for the given number of milliseconds.
-async fn sleep_ms(ms: u64) {
+pub(crate) async fn sleep_ms(ms: u64) {
     tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
 }
 
@@ -88,7 +93,7 @@ pub enum TextMatch {
 
 /// A browser page with stealth capabilities
 pub struct Page {
-    session: Session,
+    pub(crate) session: Session,
     config: Arc<StealthConfig>,
     /// Cached root `DOM.getDocument` node id (invalidated on navigation).
     root_node: std::sync::Mutex<Option<i32>>,
@@ -1264,94 +1269,6 @@ impl Page {
     }
 }
 
-fn parse_key_combo(combo: &str) -> (i32, &str) {
-    use crate::cdp::types::modifiers;
-    let parts: Vec<&str> = combo.split('+').collect();
-    let mut mods = 0;
-    let mut key = combo;
-    for (i, part) in parts.iter().enumerate() {
-        match part.to_lowercase().as_str() {
-            "ctrl" | "control" => mods |= modifiers::CTRL,
-            "alt" | "option" => mods |= modifiers::ALT,
-            "shift" => mods |= modifiers::SHIFT,
-            "cmd" | "meta" | "command" => mods |= modifiers::META,
-            _ => key = parts[i],
-        }
-    }
-    if key.is_empty() {
-        key = "+";
-    }
-    (mods, key)
-}
-
-fn key_to_codes(key: &str) -> (&str, &str, Option<i32>) {
-    static KEYS: &[(&str, &str, &str, i32)] = &[
-        ("enter", "Enter", "Enter", 13),
-        ("return", "Enter", "Enter", 13),
-        ("tab", "Tab", "Tab", 9),
-        ("escape", "Escape", "Escape", 27),
-        ("esc", "Escape", "Escape", 27),
-        ("backspace", "Backspace", "Backspace", 8),
-        ("delete", "Delete", "Delete", 46),
-        ("arrowup", "ArrowUp", "ArrowUp", 38),
-        ("up", "ArrowUp", "ArrowUp", 38),
-        ("arrowdown", "ArrowDown", "ArrowDown", 40),
-        ("down", "ArrowDown", "ArrowDown", 40),
-        ("arrowleft", "ArrowLeft", "ArrowLeft", 37),
-        ("left", "ArrowLeft", "ArrowLeft", 37),
-        ("arrowright", "ArrowRight", "ArrowRight", 39),
-        ("right", "ArrowRight", "ArrowRight", 39),
-        ("home", "Home", "Home", 36),
-        ("end", "End", "End", 35),
-        ("pageup", "PageUp", "PageUp", 33),
-        ("pagedown", "PageDown", "PageDown", 34),
-        ("space", " ", "Space", 32),
-        ("a", "a", "KeyA", 65),
-        ("b", "b", "KeyB", 66),
-        ("c", "c", "KeyC", 67),
-        ("d", "d", "KeyD", 68),
-        ("e", "e", "KeyE", 69),
-        ("f", "f", "KeyF", 70),
-        ("g", "g", "KeyG", 71),
-        ("h", "h", "KeyH", 72),
-        ("i", "i", "KeyI", 73),
-        ("j", "j", "KeyJ", 74),
-        ("k", "k", "KeyK", 75),
-        ("l", "l", "KeyL", 76),
-        ("m", "m", "KeyM", 77),
-        ("n", "n", "KeyN", 78),
-        ("o", "o", "KeyO", 79),
-        ("p", "p", "KeyP", 80),
-        ("q", "q", "KeyQ", 81),
-        ("r", "r", "KeyR", 82),
-        ("s", "s", "KeyS", 83),
-        ("t", "t", "KeyT", 84),
-        ("u", "u", "KeyU", 85),
-        ("v", "v", "KeyV", 86),
-        ("w", "w", "KeyW", 87),
-        ("x", "x", "KeyX", 88),
-        ("y", "y", "KeyY", 89),
-        ("z", "z", "KeyZ", 90),
-        ("f1", "F1", "F1", 112),
-        ("f2", "F2", "F2", 113),
-        ("f3", "F3", "F3", 114),
-        ("f4", "F4", "F4", 115),
-        ("f5", "F5", "F5", 116),
-        ("f6", "F6", "F6", 117),
-        ("f7", "F7", "F7", 118),
-        ("f8", "F8", "F8", 119),
-        ("f9", "F9", "F9", 120),
-        ("f10", "F10", "F10", 121),
-        ("f11", "F11", "F11", 122),
-        ("f12", "F12", "F12", 123),
-    ];
-    let lower = key.to_lowercase();
-    KEYS.iter()
-        .find(|(name, _, _, _)| *name == lower)
-        .map(|(_, k, c, vk)| (*k, *c, Some(*vk)))
-        .unwrap_or((key, key, None))
-}
-
 /// A captured HTTP request with its response
 #[derive(Debug, Clone)]
 pub struct CapturedRequest {
@@ -1416,308 +1333,9 @@ pub struct PageState {
     pub form_count: u32,
 }
 
-/// Bounding box of an element
-#[derive(Debug, Clone, Copy)]
-pub struct BoundingBox {
-    pub x: f64,
-    pub y: f64,
-    pub width: f64,
-    pub height: f64,
-}
-
-impl BoundingBox {
-    pub fn center(&self) -> (f64, f64) {
-        (self.x + self.width / 2.0, self.y + self.height / 2.0)
-    }
-}
-
-/// An element on the page (holds a CDP node_id, can become stale on DOM changes)
-pub struct Element<'a> {
-    page: &'a Page,
-    node_id: i32,
-}
-
-impl<'a> Element<'a> {
-    /// Get the element's center coordinates
-    pub async fn center(&self) -> Result<(f64, f64)> {
-        let model = self.page.session.get_box_model(self.node_id).await?;
-        model.try_center().ok_or_else(|| Error::ElementNotVisible {
-            selector: format!("node {}", self.node_id),
-        })
-    }
-
-    /// Click this element
-    pub async fn click(&self) -> Result<()> {
-        let (x, y) = self.center().await?;
-        self.page.click_at(x, y).await
-    }
-
-    /// Human-like click
-    pub async fn human_click(&self) -> Result<()> {
-        let (x, y) = self.center().await?;
-        self.page.human().move_and_click(x, y).await
-    }
-
-    /// Get outer HTML
-    pub async fn outer_html(&self) -> Result<String> {
-        self.page.session.get_outer_html(self.node_id).await
-    }
-
-    /// Get inner text
-    ///
-    /// Extracts text content from the element's outerHTML without using focus.
-    pub async fn text(&self) -> Result<String> {
-        self.eval_str("this.textContent || ''").await
-    }
-
-    /// Evaluate a JavaScript expression on this element via Runtime.callFunctionOn.
-    ///
-    /// The expression should use `this` to refer to the element.
-    /// Example: `"this.textContent || ''"`, `"this.tagName.toLowerCase()"`
-    async fn eval_on_element(&self, js_body: &str) -> Result<serde_json::Value> {
-        let object_id = self.page.session.resolve_node(self.node_id).await?;
-        let func = format!("function() {{ return {}; }}", js_body);
-        let result = self
-            .page
-            .session
-            .call_function_on(&object_id, &func)
-            .await?;
-        Ok(result.result.value.unwrap_or(serde_json::Value::Null))
-    }
-
-    /// Evaluate JS on element, return as String (empty string on null/non-string)
-    async fn eval_str(&self, js_body: &str) -> Result<String> {
-        let value = self.eval_on_element(js_body).await?;
-        Ok(value.as_str().unwrap_or("").to_string())
-    }
-
-    /// Evaluate JS on element, return as bool with a default
-    async fn eval_bool(&self, js_body: &str, default: bool) -> Result<bool> {
-        let value = self.eval_on_element(js_body).await?;
-        Ok(value.as_bool().unwrap_or(default))
-    }
-
-    /// Type text into this element
-    pub async fn type_text(&self, text: &str) -> Result<()> {
-        self.click().await?;
-        sleep_ms(INTERACTION_DELAY_MS).await;
-        self.page.session.insert_text(text).await
-    }
-
-    /// Focus this element
-    pub async fn focus(&self) -> Result<()> {
-        self.page.session.focus(self.node_id).await
-    }
-    /// Check if the element is visible (has a computable box model)
-    pub async fn is_visible(&self) -> Result<bool> {
-        match self.page.session.get_box_model(self.node_id).await {
-            Ok(_) => Ok(true),
-            Err(Error::Cdp { message, .. }) if message.contains("box model") => Ok(false),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Get the element's bounding box
-    ///
-    /// Returns None if the element is not visible/rendered.
-    pub async fn bounding_box(&self) -> Option<BoundingBox> {
-        match self.page.session.get_box_model(self.node_id).await {
-            Ok(model) => {
-                let content = &model.content;
-                if content.len() >= 8 {
-                    // content is [x1,y1, x2,y2, x3,y3, x4,y4] for a quad
-                    // Handle rotated/transformed elements by finding actual bounds
-                    let xs = [content[0], content[2], content[4], content[6]];
-                    let ys = [content[1], content[3], content[5], content[7]];
-
-                    let min_x = xs.iter().copied().fold(f64::INFINITY, f64::min);
-                    let max_x = xs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-                    let min_y = ys.iter().copied().fold(f64::INFINITY, f64::min);
-                    let max_y = ys.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-
-                    Some(BoundingBox {
-                        x: min_x,
-                        y: min_y,
-                        width: max_x - min_x,
-                        height: max_y - min_y,
-                    })
-                } else {
-                    None
-                }
-            }
-            Err(_) => None,
-        }
-    }
-
-    /// Get an attribute value
-    pub async fn get_attribute(&self, name: &str) -> Result<Option<String>> {
-        let escaped_name = escape_js_string(name);
-        let value = self
-            .eval_on_element(&format!("this.getAttribute('{}')", escaped_name))
-            .await?;
-
-        if value.is_null() {
-            return Ok(None);
-        }
-        if let Some(s) = value.as_str() {
-            return Ok(Some(s.to_string()));
-        }
-        Ok(None)
-    }
-
-    /// Get the tag name of the element (e.g., "div", "input", "a")
-    pub async fn tag_name(&self) -> Result<String> {
-        self.eval_str("this.tagName.toLowerCase()").await
-    }
-
-    /// Check if the element is enabled (not disabled)
-    pub async fn is_enabled(&self) -> Result<bool> {
-        self.eval_bool("!this.disabled", true).await
-    }
-
-    /// Check if a checkbox/radio is checked
-    pub async fn is_checked(&self) -> Result<bool> {
-        self.eval_bool("this.checked === true", false).await
-    }
-
-    /// Get the value of an input element
-    pub async fn value(&self) -> Result<String> {
-        self.eval_str("this.value || ''").await
-    }
-
-    /// Get computed CSS property value
-    pub async fn css(&self, property: &str) -> Result<String> {
-        let escaped = escape_js_string(property);
-        self.eval_str(&format!(
-            "getComputedStyle(this).getPropertyValue('{}')",
-            escaped
-        ))
-        .await
-    }
-
-    /// Scroll this element into view
-    pub async fn scroll_into_view(&self) -> Result<()> {
-        let object_id = self.page.session.resolve_node(self.node_id).await?;
-        self.page
-            .session
-            .call_function_on(
-                &object_id,
-                "function() { this.scrollIntoView({ behavior: 'smooth', block: 'center' }); }",
-            )
-            .await?;
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_key_combo_simple() {
-        let (mods, key) = parse_key_combo("Enter");
-        assert_eq!(mods, 0);
-        assert_eq!(key, "Enter");
-    }
-
-    #[test]
-    fn test_parse_key_combo_ctrl() {
-        use crate::cdp::types::modifiers;
-        let (mods, key) = parse_key_combo("Ctrl+A");
-        assert_eq!(mods, modifiers::CTRL);
-        assert_eq!(key, "A");
-    }
-
-    #[test]
-    fn test_parse_key_combo_cmd_shift() {
-        use crate::cdp::types::modifiers;
-        let (mods, key) = parse_key_combo("Cmd+Shift+S");
-        assert_eq!(mods, modifiers::META | modifiers::SHIFT);
-        assert_eq!(key, "S");
-    }
-
-    #[test]
-    fn test_parse_key_combo_all_modifiers() {
-        use crate::cdp::types::modifiers;
-        let (mods, key) = parse_key_combo("Ctrl+Alt+Shift+Cmd+X");
-        assert_eq!(
-            mods,
-            modifiers::CTRL | modifiers::ALT | modifiers::SHIFT | modifiers::META
-        );
-        assert_eq!(key, "X");
-    }
-
-    #[test]
-    fn test_parse_key_combo_case_insensitive() {
-        use crate::cdp::types::modifiers;
-        let (mods, key) = parse_key_combo("ctrl+a");
-        assert_eq!(mods, modifiers::CTRL);
-        assert_eq!(key, "a");
-    }
-
-    #[test]
-    fn test_key_to_codes_enter() {
-        let (key, code, vk) = key_to_codes("Enter");
-        assert_eq!(key, "Enter");
-        assert_eq!(code, "Enter");
-        assert_eq!(vk, Some(13));
-    }
-
-    #[test]
-    fn test_key_to_codes_tab() {
-        let (key, code, vk) = key_to_codes("Tab");
-        assert_eq!(key, "Tab");
-        assert_eq!(code, "Tab");
-        assert_eq!(vk, Some(9));
-    }
-
-    #[test]
-    fn test_key_to_codes_letter() {
-        let (key, code, vk) = key_to_codes("a");
-        assert_eq!(key, "a");
-        assert_eq!(code, "KeyA");
-        assert_eq!(vk, Some(65));
-    }
-
-    #[test]
-    fn test_key_to_codes_arrow() {
-        let (key, code, vk) = key_to_codes("ArrowDown");
-        assert_eq!(key, "ArrowDown");
-        assert_eq!(code, "ArrowDown");
-        assert_eq!(vk, Some(40));
-    }
-
-    #[test]
-    fn test_key_to_codes_case_insensitive() {
-        let (key, code, vk) = key_to_codes("ESCAPE");
-        assert_eq!(key, "Escape");
-        assert_eq!(code, "Escape");
-        assert_eq!(vk, Some(27));
-    }
-
-    #[test]
-    fn test_key_to_codes_alias() {
-        // "esc" should work as alias for "Escape"
-        let (key, code, vk) = key_to_codes("esc");
-        assert_eq!(key, "Escape");
-        assert_eq!(code, "Escape");
-        assert_eq!(vk, Some(27));
-
-        // "up" should work as alias for "ArrowUp"
-        let (key, code, vk) = key_to_codes("up");
-        assert_eq!(key, "ArrowUp");
-        assert_eq!(code, "ArrowUp");
-        assert_eq!(vk, Some(38));
-    }
-
-    #[test]
-    fn test_key_to_codes_unknown() {
-        // Unknown keys should pass through
-        let (key, code, vk) = key_to_codes("SomeWeirdKey");
-        assert_eq!(key, "SomeWeirdKey");
-        assert_eq!(code, "SomeWeirdKey");
-        assert_eq!(vk, None);
-    }
 
     #[test]
     fn test_escape_js_string() {
@@ -1756,23 +1374,6 @@ mod tests {
         assert_eq!(escape_js_string("${"), "\\${");
         assert_eq!(escape_js_string("\u{2028}"), "\\u2028");
         assert_eq!(escape_js_string("\u{2029}"), "\\u2029");
-    }
-
-    #[test]
-    fn test_parse_key_combo_literal_plus() {
-        // A lone "+" is a literal key, not a separator artifact.
-        let (mods, key) = parse_key_combo("+");
-        assert_eq!(mods, 0);
-        assert_eq!(key, "+");
-    }
-
-    #[test]
-    fn test_parse_key_combo_shift_plus() {
-        // "Shift++" is SHIFT modifier plus the literal "+" key.
-        use crate::cdp::types::modifiers;
-        let (mods, key) = parse_key_combo("Shift++");
-        assert_eq!(mods, modifiers::SHIFT);
-        assert_eq!(key, "+");
     }
 
     #[test]

--- a/src/page.rs
+++ b/src/page.rs
@@ -5,9 +5,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::cdp::{Cookie, MouseButton, MouseEventType, Session};
+use crate::cdp::{MouseButton, MouseEventType, Session};
 use crate::error::{Error, Result};
 use crate::keyboard::{key_to_codes, parse_key_combo};
+use crate::session::SessionCookie;
 use crate::stealth::Human;
 use crate::StealthConfig;
 
@@ -643,9 +644,23 @@ impl Page {
         }
         Ok(result.result)
     }
-    /// Get all cookies
-    pub async fn cookies(&self) -> Result<Vec<Cookie>> {
-        self.session.get_cookies(None).await
+    /// Get all cookies as domain `SessionCookie`s (no `cdp::types` leak).
+    pub async fn cookies(&self) -> Result<Vec<SessionCookie>> {
+        let cookies = self.session.get_cookies(None).await?;
+        Ok(cookies
+            .into_iter()
+            .map(|c| SessionCookie {
+                name: c.name,
+                value: c.value,
+                domain: c.domain,
+                path: c.path,
+                secure: c.secure,
+                http_only: c.http_only,
+                same_site: c.same_site,
+                // Session cookies have no meaningful expiry.
+                expires: if c.session { None } else { Some(c.expires) },
+            })
+            .collect())
     }
 
     /// Set a cookie
@@ -680,12 +695,23 @@ impl Page {
         self.session.clear_all_cookies().await
     }
 
-    /// Bulk-import cookies (e.g., restored from a prior dump_storage call).
-    pub async fn set_cookies_bulk(
-        &self,
-        cookies: Vec<crate::cdp::types::NetworkSetCookie>,
-    ) -> Result<()> {
-        self.session.set_cookies(cookies).await
+    /// Bulk-import cookies (e.g., restored from a prior `cookies()` dump).
+    pub async fn set_cookies_bulk(&self, cookies: Vec<SessionCookie>) -> Result<()> {
+        let cdp_cookies = cookies
+            .into_iter()
+            .map(|c| crate::cdp::types::NetworkSetCookie {
+                name: c.name,
+                value: c.value,
+                url: None,
+                domain: Some(c.domain),
+                path: Some(c.path),
+                secure: Some(c.secure),
+                http_only: Some(c.http_only),
+                same_site: c.same_site,
+                expires: c.expires,
+            })
+            .collect();
+        self.session.set_cookies(cdp_cookies).await
     }
 
     /// Set extra HTTP headers sent with every subsequent request from this page.

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::cdp::Cookie;
 use crate::error::Result;
 
 /// Browser cookie (simplified, serializable)
@@ -20,25 +19,6 @@ pub struct SessionCookie {
     pub http_only: bool,
     pub same_site: Option<String>,
     pub expires: Option<f64>,
-}
-
-impl From<Cookie> for SessionCookie {
-    fn from(c: Cookie) -> Self {
-        Self {
-            name: c.name,
-            value: c.value,
-            domain: c.domain,
-            path: c.path,
-            secure: c.secure,
-            http_only: c.http_only,
-            same_site: c.same_site,
-            expires: if c.expires > 0.0 {
-                Some(c.expires)
-            } else {
-                None
-            },
-        }
-    }
 }
 
 /// Exported browser session
@@ -57,9 +37,9 @@ pub struct BrowserSession {
 
 impl BrowserSession {
     /// Create a new session from cookies
-    pub fn new(cookies: Vec<Cookie>, user_agent: String, url: String) -> Self {
+    pub fn new(cookies: Vec<SessionCookie>, user_agent: String, url: String) -> Self {
         Self {
-            cookies: cookies.into_iter().map(SessionCookie::from).collect(),
+            cookies,
             user_agent,
             url,
             extra_headers: HashMap::new(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,13 +11,21 @@ use crate::error::Result;
 /// Browser cookie (simplified, serializable)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionCookie {
+    /// Cookie name.
     pub name: String,
+    /// Cookie value.
     pub value: String,
+    /// Domain the cookie applies to.
     pub domain: String,
+    /// Path the cookie applies to.
     pub path: String,
+    /// Whether the cookie is sent only over HTTPS.
     pub secure: bool,
+    /// Whether the cookie is inaccessible to JavaScript.
     pub http_only: bool,
+    /// SameSite policy ("Strict", "Lax", "None"), if set.
     pub same_site: Option<String>,
+    /// Expiry as a Unix timestamp in seconds, or `None` for a session cookie.
     pub expires: Option<f64>,
 }
 

--- a/src/stealth/evasions.rs
+++ b/src/stealth/evasions.rs
@@ -810,11 +810,6 @@ pub fn build_evasion_script(config: &StealthConfig) -> String {
     build_evasion_script_for(config, &fp)
 }
 
-/// Get the full evasion script (all options enabled)
-pub fn full_evasion_script() -> String {
-    build_evasion_script(&StealthConfig::default())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/stealth/fingerprint.rs
+++ b/src/stealth/fingerprint.rs
@@ -108,7 +108,9 @@ pub fn random_user_agent() -> String {
 /// Browser fingerprint data — a single coherent identity.
 #[derive(Debug, Clone)]
 pub struct Fingerprint {
+    /// Full User-Agent string.
     pub user_agent: String,
+    /// Operating system platform.
     pub platform: Platform,
     /// Chrome major version, e.g. "140" (drives `Sec-CH-UA` brand versions).
     pub chrome_major: String,
@@ -116,20 +118,32 @@ pub struct Fingerprint {
     pub chrome_full_version: String,
     /// Client-hint OS version, e.g. "15.0.0".
     pub platform_version: String,
+    /// Screen width in pixels.
     pub screen_width: u32,
+    /// Screen height in pixels.
     pub screen_height: u32,
+    /// Screen color depth in bits.
     pub color_depth: u8,
+    /// `navigator.hardwareConcurrency` (logical CPU count).
     pub hardware_concurrency: u8,
+    /// `navigator.deviceMemory` in gigabytes.
     pub device_memory: u8,
+    /// IANA timezone name.
     pub timezone: String,
+    /// `navigator.languages` list.
     pub languages: Vec<String>,
+    /// Spoofed WebGL unmasked vendor.
     pub webgl_vendor: String,
+    /// Spoofed WebGL unmasked renderer.
     pub webgl_renderer: String,
 }
 
+/// Operating system platform for a fingerprint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Platform {
+    /// macOS.
     MacOS,
+    /// Windows.
     Windows,
 }
 

--- a/src/stealth/mod.rs
+++ b/src/stealth/mod.rs
@@ -11,7 +11,7 @@ pub mod fingerprint;
 pub mod human;
 pub mod patcher;
 
-pub use evasions::{build_evasion_script, build_evasion_script_for, full_evasion_script};
+pub use evasions::{build_evasion_script, build_evasion_script_for};
 pub use fingerprint::{random_user_agent, Fingerprint, Platform};
 pub use human::{Human, HumanSpeed};
 pub use patcher::{find_chrome, ChromePatcher};

--- a/src/stealth/patcher.rs
+++ b/src/stealth/patcher.rs
@@ -76,44 +76,40 @@ static PATCH_PATTERNS: &[PatchPattern] = &[
     },
 ];
 
-/// Compiled pattern matcher (lazy initialized)
+/// Matcher over all patterns (find) and over only rewritten patterns (verify).
 static PATTERN_MATCHER: OnceLock<AhoCorasick> = OnceLock::new();
+static VERIFY_MATCHER: OnceLock<AhoCorasick> = OnceLock::new();
 
-fn get_pattern_matcher() -> Result<&'static AhoCorasick> {
-    // OnceLock doesn't support fallible init, so we handle it via a separate error check.
-    // The patterns are static &[u8] literals — this will only fail on a bug in aho-corasick.
-    if let Some(ac) = PATTERN_MATCHER.get() {
+/// Build (once) an Aho-Corasick matcher over `PATCH_PATTERNS`, optionally
+/// excluding `Skip`-strategy patterns (those are detected but never rewritten,
+/// so verification must ignore them).
+fn build_matcher(
+    cell: &'static OnceLock<AhoCorasick>,
+    include_skip: bool,
+) -> Result<&'static AhoCorasick> {
+    if let Some(ac) = cell.get() {
         return Ok(ac);
     }
-    let patterns: Vec<&[u8]> = PATCH_PATTERNS.iter().map(|p| p.pattern).collect();
+    let patterns: Vec<&[u8]> = PATCH_PATTERNS
+        .iter()
+        .filter(|p| include_skip || p.strategy != PatchStrategy::Skip)
+        .map(|p| p.pattern)
+        .collect();
     let ac = AhoCorasick::new(&patterns).map_err(|e| {
         Error::patching(
             "init",
             format!("Failed to build Aho-Corasick automaton: {}", e),
         )
     })?;
-    Ok(PATTERN_MATCHER.get_or_init(|| ac))
+    Ok(cell.get_or_init(|| ac))
 }
 
-/// Matcher for patterns that patching actually rewrites (excludes `Skip`).
-static VERIFY_MATCHER: OnceLock<AhoCorasick> = OnceLock::new();
+fn get_pattern_matcher() -> Result<&'static AhoCorasick> {
+    build_matcher(&PATTERN_MATCHER, true)
+}
 
 fn get_verify_matcher() -> Result<&'static AhoCorasick> {
-    if let Some(ac) = VERIFY_MATCHER.get() {
-        return Ok(ac);
-    }
-    let patterns: Vec<&[u8]> = PATCH_PATTERNS
-        .iter()
-        .filter(|p| p.strategy != PatchStrategy::Skip)
-        .map(|p| p.pattern)
-        .collect();
-    let ac = AhoCorasick::new(&patterns).map_err(|e| {
-        Error::patching(
-            "init",
-            format!("Failed to build verification automaton: {}", e),
-        )
-    })?;
-    Ok(VERIFY_MATCHER.get_or_init(|| ac))
+    build_matcher(&VERIFY_MATCHER, false)
 }
 
 /// Stable temp-subdir name for the patched copy, keyed on the original binary's

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,7 @@
 //! These tests require Chrome to be installed and available.
 //! Run with: cargo test --test integration -- --ignored
 
-use eoka::{Browser, StealthConfig};
+use eoka::Browser;
 
 /// Check if Chrome is available
 fn chrome_available() -> bool {
@@ -30,8 +30,7 @@ async fn test_browser_launch_visible() {
         return;
     }
 
-    let config = StealthConfig::visible();
-    let browser = Browser::launch_with_config(config)
+    let browser = Browser::launch_visible()
         .await
         .expect("Failed to launch browser");
     browser.close().await.expect("Failed to close browser");


### PR DESCRIPTION
## Summary

This is the 0.5.0 refactor branch. It narrows the public API, moves the CDP transport onto a tested async WebSocket stack, and makes the high-level page/element APIs easier to reuse.

Key changes:
- Rewrites the CDP transport on `tokio-tungstenite` with an async reader task and multi-consumer broadcast events.
- Keeps hand-written CDP protocol structs crate-private, with typed `Session`/`Connection` wrappers and a narrow generic `Session::send` escape hatch.
- Changes `Element<'a>` into an owned `Element` handle that carries a cheap `Page` clone and is `Send + 'static`.
- Splits `page.rs` into clearer `page.rs`, `element.rs`, and internal `keyboard.rs` modules.
- Cleans up error handling by folding `CdpSimple` into `Error::Cdp`, adding `Error::cdp_msg`, and marking `Error` as `#[non_exhaustive]`.
- Updates cookie APIs to use public `SessionCookie` values instead of leaking CDP cookie structs.
- Cleans up patcher matching and Chrome discovery behavior.
- Adds `Browser::launch_visible()`, `Browser::launch_debug()`, and `Browser::launch_with(...)` convenience helpers.
- Updates README, crate docs, examples, changelog, and API documentation for the new surface.

## Breaking Changes

| Before | After |
|---|---|
| `Element<'a>` | `Element` owned handle |
| `Error::CdpSimple(s)` | `Error::cdp_msg(s)` / `Error::Cdp { method: None, code: None, message }` |
| `Error::Cdp { method: String, code: i64, .. }` | `method: Option<String>, code: Option<i64>` |
| exhaustive matches on `Error` | add a wildcard arm; `Error` is `#[non_exhaustive]` |
| `page.cookies() -> Vec<cdp::Cookie>` | `page.cookies() -> Vec<SessionCookie>` |
| `page.set_cookies_bulk(Vec<NetworkSetCookie>)` | `page.set_cookies_bulk(Vec<SessionCookie>)` |
| public `eoka::cdp::types::*` | crate-private CDP structs |
| `Transport::new*` / `Transport::connect*` sync constructors | async constructors |
| `full_evasion_script()` | removed |

## Validation

Current branch validation:
- `cargo fmt --all --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo build`
- `cargo build --examples`
- `cargo test`

`cargo test` currently passes with 75 unit tests and 3 doctests. The 22 Chrome integration tests remain ignored by default because they require Chrome.