### PR TITLE
feat: persist browser identity with profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eoka"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT"

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -168,17 +168,26 @@ impl Browser {
     pub async fn launch_with_config(config: StealthConfig) -> Result<Self> {
         let config = Arc::new(config);
 
-        // Create unique user data directory
-        let instance_id = BROWSER_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let user_data_dir = std::env::temp_dir().join(format!(
-            "eoka-browser-{}-{}",
-            std::process::id(),
-            instance_id
-        ));
-
-        // Clean up any stale data
-        let _ = std::fs::remove_dir_all(&user_data_dir);
-        std::fs::create_dir_all(&user_data_dir)?;
+        // Ephemeral calls use a disposable profile. A caller-provided profile
+        // is durable and must never be wiped by Eoka.
+        let (user_data_dir, owns_user_data_dir) = match config.user_data_dir.as_deref() {
+            Some(path) => {
+                let path = PathBuf::from(path);
+                std::fs::create_dir_all(&path)?;
+                (path, false)
+            }
+            None => {
+                let instance_id = BROWSER_COUNTER.fetch_add(1, Ordering::Relaxed);
+                let path = std::env::temp_dir().join(format!(
+                    "eoka-browser-{}-{}",
+                    std::process::id(),
+                    instance_id
+                ));
+                let _ = std::fs::remove_dir_all(&path);
+                std::fs::create_dir_all(&path)?;
+                (path, true)
+            }
+        };
 
         // Clean up the temp user-data-dir on any failure past this point.
         let launch = async {
@@ -187,7 +196,10 @@ impl Browser {
                 None => find_chrome()?,
             };
 
-            let chrome_path = if config.patch_binary {
+            // Patching a browser binary is not appropriate for a durable
+            // user-owned profile. Keep that mode close to normal Chromium and
+            // let its profile provide continuity instead of fresh spoofing.
+            let chrome_path = if config.patch_binary && owns_user_data_dir {
                 ChromePatcher::new(&chrome_path)?.get_patched_path()?
             } else {
                 chrome_path
@@ -198,13 +210,14 @@ impl Browser {
             } else {
                 None
             };
-            let fingerprint = Fingerprint::resolve(
+            let fingerprint = Fingerprint::resolve_for_profile(
                 config
                     .user_agent
                     .as_deref()
                     .or(detected_user_agent.as_deref()),
                 config.timezone.as_deref(),
-            );
+                (!owns_user_data_dir).then_some(user_data_dir.as_path()),
+            )?;
 
             // Build args
             let mut args = stealth_args(&config, &fingerprint);
@@ -231,7 +244,9 @@ impl Browser {
         let (connection, fingerprint) = match launch {
             Ok(result) => result,
             Err(e) => {
-                let _ = std::fs::remove_dir_all(&user_data_dir);
+                if owns_user_data_dir {
+                    let _ = std::fs::remove_dir_all(&user_data_dir);
+                }
                 return Err(e);
             }
         };
@@ -241,7 +256,7 @@ impl Browser {
         Ok(Self {
             connection,
             config,
-            user_data_dir: Some(user_data_dir),
+            user_data_dir: owns_user_data_dir.then_some(user_data_dir),
             fingerprint: Some(fingerprint),
             evasion_script,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,9 @@ pub struct StealthConfig {
     pub debug_dir: Option<String>,
     /// Proxy server URL (e.g. "http://host:port")
     pub proxy: Option<String>,
+    /// Durable Chrome user-data directory. When set, Eoka preserves the
+    /// profile and its full fingerprint identity across browser launches.
+    pub user_data_dir: Option<String>,
     /// Proxy username for authenticated proxies
     pub proxy_username: Option<String>,
     /// Proxy password for authenticated proxies
@@ -164,6 +167,7 @@ impl Default for StealthConfig {
             debug: false,
             debug_dir: None,
             proxy: None,
+            user_data_dir: None,
             proxy_username: None,
             proxy_password: None,
             cdp_timeout: 30,

--- a/src/stealth/evasions.rs
+++ b/src/stealth/evasions.rs
@@ -792,7 +792,7 @@ pub fn build_evasion_script_for(config: &StealthConfig, fp: &Fingerprint) -> Str
             .join(",")
     );
     let language = fp.languages.first().cloned().unwrap_or_default();
-    let noise_seed = fastrand::u32(1..=u32::MAX);
+    let noise_seed = fp.noise_seed;
 
     let script = format!("(function(){{{}}})();", scripts.join("\n"));
     script

--- a/src/stealth/fingerprint.rs
+++ b/src/stealth/fingerprint.rs
@@ -1,6 +1,18 @@
 //! Browser fingerprint generation
 //!
-//! Generates realistic, randomized, internally consistent browser fingerprints.
+//! Generates realistic, internally consistent browser fingerprints.
+//!
+//! Ephemeral browsers may use a random identity. A browser backed by a durable
+//! user-data directory must not: changing WebGL, CPU, or memory values between
+//! visits makes a supposedly persistent login look like a new device.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+const PERSISTED_FINGERPRINT_FILE: &str = ".eoka-fingerprint.json";
 
 /// Recent Chrome versions as (major, full) pairs.
 const CHROME_VERSIONS: &[(&str, &str)] = &[
@@ -130,7 +142,7 @@ pub fn random_user_agent() -> String {
 }
 
 /// Browser fingerprint data — a single coherent identity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Fingerprint {
     /// Full User-Agent string.
     pub user_agent: String,
@@ -160,10 +172,13 @@ pub struct Fingerprint {
     pub webgl_vendor: String,
     /// Spoofed WebGL unmasked renderer.
     pub webgl_renderer: String,
+    /// Stable canvas/audio perturbation seed for this identity.
+    #[serde(default = "random_noise_seed")]
+    pub noise_seed: u32,
 }
 
 /// Operating system platform for a fingerprint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Platform {
     /// macOS.
     MacOS,
@@ -209,6 +224,7 @@ impl Fingerprint {
             languages: vec!["en-US".to_string(), "en".to_string()],
             webgl_vendor: webgl_vendor.to_string(),
             webgl_renderer,
+            noise_seed: random_noise_seed(),
         }
     }
 
@@ -257,6 +273,55 @@ impl Fingerprint {
         fp
     }
 
+    /// Resolves an identity for a browser profile, storing it beside the
+    /// profile on first use. Explicit UA/timezone values are allowed only when
+    /// they agree with an existing identity; silently changing either would
+    /// defeat the point of a durable profile.
+    pub fn resolve_for_profile(
+        user_agent: Option<&str>,
+        timezone: Option<&str>,
+        profile_dir: Option<&Path>,
+    ) -> io::Result<Self> {
+        let Some(profile_dir) = profile_dir else {
+            return Ok(Self::resolve(user_agent, timezone));
+        };
+
+        let path = profile_dir.join(PERSISTED_FINGERPRINT_FILE);
+        if path.exists() {
+            let contents = fs::read(&path)?;
+            let fingerprint: Self = serde_json::from_slice(&contents).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid persisted browser identity {}: {error}", path.display()),
+                )
+            })?;
+            if let Some(user_agent) = user_agent {
+                if user_agent != fingerprint.user_agent {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "configured user agent conflicts with persisted browser identity",
+                    ));
+                }
+            }
+            if let Some(timezone) = timezone {
+                if timezone != fingerprint.timezone {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "configured timezone conflicts with persisted browser identity",
+                    ));
+                }
+            }
+            return Ok(fingerprint);
+        }
+
+        let fingerprint = Self::resolve(user_agent, timezone);
+        let temporary = profile_dir.join(format!("{PERSISTED_FINGERPRINT_FILE}.tmp-{}", std::process::id()));
+        let encoded = serde_json::to_vec_pretty(&fingerprint).map_err(io::Error::other)?;
+        fs::write(&temporary, encoded)?;
+        fs::rename(temporary, path)?;
+        Ok(fingerprint)
+    }
+
     /// `navigator.platform` value consistent with this fingerprint.
     pub fn nav_platform(&self) -> &'static str {
         match self.platform {
@@ -296,6 +361,10 @@ impl Fingerprint {
             ("Not?A_Brand".to_string(), "24.0.0.0".to_string()),
         ]
     }
+}
+
+fn random_noise_seed() -> u32 {
+    fastrand::u32(1..=u32::MAX)
 }
 
 fn native_platform() -> Platform {
@@ -383,6 +452,39 @@ mod tests {
         let ua = Fingerprint::native_chrome_user_agent("150.0.7871.182").unwrap();
         assert!(ua.contains("Chrome/150.0.7871.182"));
         assert!(Fingerprint::native_chrome_user_agent("not-a-version").is_none());
+    }
+
+    #[test]
+    fn test_profile_identity_is_stable_across_launches() {
+        let dir = std::env::temp_dir().join(format!(
+            "eoka-fingerprint-test-{}-{}",
+            std::process::id(),
+            fastrand::u64(..)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let first = Fingerprint::resolve_for_profile(None, Some("America/Los_Angeles"), Some(&dir))
+            .unwrap();
+        let second = Fingerprint::resolve_for_profile(None, Some("America/Los_Angeles"), Some(&dir))
+            .unwrap();
+        assert_eq!(first.user_agent, second.user_agent);
+        assert_eq!(first.hardware_concurrency, second.hardware_concurrency);
+        assert_eq!(first.device_memory, second.device_memory);
+        assert_eq!(first.webgl_renderer, second.webgl_renderer);
+        assert_eq!(first.noise_seed, second.noise_seed);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn test_profile_identity_rejects_conflicting_user_agent() {
+        let dir = std::env::temp_dir().join(format!(
+            "eoka-fingerprint-test-{}-{}",
+            std::process::id(),
+            fastrand::u64(..)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        Fingerprint::resolve_for_profile(Some("Mozilla/5.0 first"), None, Some(&dir)).unwrap();
+        assert!(Fingerprint::resolve_for_profile(Some("Mozilla/5.0 second"), None, Some(&dir)).is_err());
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     // Over many samples, every random fingerprint must be internally coherent:


### PR DESCRIPTION
Adds a durable profile mode that preserves the Chromium user-data directory and a full browser identity across launches.

Also disables binary patching for durable profiles and verifies identity persistence in tests.