### PR TITLE
Add Page::set_javascript_enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ src/
 
 ### Page - Configuration
 - `page.set_bypass_csp(enabled)` - Disable CSP enforcement
+- `page.set_javascript_enabled(enabled)` - Enable/disable JS execution (must be called before navigation)
 - `page.set_user_agent(ua)` - Override User-Agent
 - `page.ignore_cert_errors(ignore)` - Skip TLS verification
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eoka"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ page.disable_request_capture().await?;
 
 ```rust
 page.set_bypass_csp(true).await?;           // disable CSP
+page.set_javascript_enabled(false).await?;  // disable JS entirely (before navigation)
 page.set_user_agent("custom UA").await?;
 page.ignore_cert_errors(true).await?;
 page.accept_dialog(None).await?;            // accept alert/confirm

--- a/src/cdp/connection.rs
+++ b/src/cdp/connection.rs
@@ -234,6 +234,16 @@ impl Session {
             .await
     }
 
+    /// Switch JS execution off/on for the current page.
+    /// Must be called before navigation to take effect.
+    pub(crate) async fn set_script_execution_disabled(&self, disabled: bool) -> Result<()> {
+        self.send_void(
+            "Emulation.setScriptExecutionDisabled",
+            &EmulationSetScriptExecutionDisabled { value: disabled },
+        )
+        .await
+    }
+
     /// Override the User-Agent string (and optionally Accept-Language).
     pub(crate) async fn set_user_agent(
         &self,

--- a/src/cdp/types.rs
+++ b/src/cdp/types.rs
@@ -745,6 +745,13 @@ pub struct PageSetBypassCSP {
     pub enabled: bool,
 }
 
+/// Emulation.setScriptExecutionDisabled — switch JS execution off/on for the page
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmulationSetScriptExecutionDisabled {
+    pub value: bool,
+}
+
 /// A single (brand, version) entry in `Sec-CH-UA` client-hint brand lists.
 #[derive(Debug, Clone, Serialize)]
 pub struct UserAgentBrandVersion {

--- a/src/page.rs
+++ b/src/page.rs
@@ -808,6 +808,12 @@ impl Page {
         self.session.set_bypass_csp(enabled).await
     }
 
+    /// Enable or disable JavaScript execution for the current page.
+    /// Must be called before navigation to take effect.
+    pub async fn set_javascript_enabled(&self, enabled: bool) -> Result<()> {
+        self.session.set_script_execution_disabled(!enabled).await
+    }
+
     /// Override the User-Agent string for this page.
     pub async fn set_user_agent(&self, user_agent: &str) -> Result<()> {
         self.session.set_user_agent(user_agent, None).await


### PR DESCRIPTION
## Summary
- Wraps `Emulation.setScriptExecutionDisabled` as `Page::set_javascript_enabled(bool)`, following the same pattern as `set_bypass_csp` (`Session::set_script_execution_disabled` + `EmulationSetScriptExecutionDisabled` CDP type).
- No transport filtering change needed — `Emulation.setScriptExecutionDisabled` isn't in `is_blocked`, and doesn't need `is_risky` either (a page with JS fully disabled can't run detection JS to notice the flag).
- Foundation for a NoScript-style per-domain allow/block policy being built on top of this in `eoka-cli`.
- Bumps to 0.5.6.

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib` (80/80 passing)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] Manual: throwaway example toggling `set_javascript_enabled` around a `data:` URL with an inline `<script>` that mutates the DOM — confirmed the mutation is skipped when disabled and happens when re-enabled