### PR TITLE
Bypass TLS cert errors before a page's first navigation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eoka"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ page.accept_dialog(None).await?;            // accept alert/confirm
 page.dismiss_dialog().await?;               // dismiss dialog
 ```
 
+`page.ignore_cert_errors` takes effect only for navigations issued after the
+call — too late for `new_page(url)`'s own initial navigate. For a bad cert on
+the very first load (e.g. an `.onion` service redirecting `http://` →
+untrusted `https://`), set `StealthConfig.ignore_cert_errors = true` instead,
+or use `new_blank_page()` + `ignore_cert_errors(true)` + `goto()`.
+
 ### Retry
 
 ```rust

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -526,6 +526,10 @@ impl Browser {
             session.fetch_enable(true).await?;
         }
 
+        if self.config.ignore_cert_errors {
+            session.set_ignore_cert_errors(true).await?;
+        }
+
         if !self.config.live_session {
             if let Some(ref fp) = self.fingerprint {
                 session.set_user_agent_full(ua_override_for(fp)).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,12 @@ pub struct StealthConfig {
     /// Drop "detectable" CDP commands like `Runtime.enable` silently.
     /// Defaults to true. Set to false in connect mode to get full DevTools-like control.
     pub filter_cdp: bool,
+    /// Ignore TLS certificate errors on every page from creation, before the
+    /// first navigation. `Page::ignore_cert_errors` is applied too late for
+    /// `new_page`'s own initial navigate — this covers self-signed/expired
+    /// certs (e.g. .onion services) hit on the very first load. Defaults to
+    /// false.
+    pub ignore_cert_errors: bool,
 }
 
 impl Default for StealthConfig {
@@ -193,6 +199,7 @@ impl Default for StealthConfig {
             aggressive_cdp_evasion: false,
             live_session: false,
             filter_cdp: true,
+            ignore_cert_errors: false,
         }
     }
 }


### PR DESCRIPTION
## Summary
- `page.ignore_cert_errors()` only takes effect for navigations issued after the call, so it can't cover `new_page(url)`'s own initial navigate.
- Surfaced by a real case: reaching a Tor `.onion` service that redirects `http://` → an untrusted `https://` cert threw `ERR_CERT_AUTHORITY_INVALID` on first load, with no way to bypass it through the convenience path (the only workaround was launching Chrome manually with `--ignore-certificate-errors`).
- Adds `StealthConfig.ignore_cert_errors`, applied in `setup_session` (shared by `new_page`/`new_blank_page`/`attach_page`) before any navigation is issued.
- Bumps to 0.5.7.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --lib` (101 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)