### PR TITLE
feat: harden stealth stack against server-side fingerprinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.5.8] - 2026-08-29
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,93 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **`Fingerprint` is now the single source of platform truth.** All
+  emulated-machine data lives on the fingerprint and is persisted with durable
+  profiles: `voices` (`SpeechVoice` list, platform-correct and stable per
+  identity) and `media_devices` (`MediaDevicesSpec` — counts typed to the
+  claimed OS, e.g. Linux desktops usually have no webcam). Evasion scripts are
+  now dumb templates: placeholder values are filled from one list and must all
+  come from the fingerprint (guarded by `test_placeholders_are_filled`).
+- Derived platform values are methods, not ad-hoc logic: `ch_architecture()`
+  replaces the "Apple M" renderer string-matching hack in client hints, and
+  `ui_chrome_height()` gives per-OS taskbar/menu-bar heights for
+  `screen.availHeight` (previously a hardcoded Windows 40px).
+- Fake media-device IDs are generated from the identity's noise seed in Rust,
+  stable per profile and distinct across profiles; the JS no longer derives
+  them.
+- **Breaking:** persisted identities missing the new fields no longer load —
+  profiles created before this change must be deleted (durable-profile
+  directories under `~/.local/state/eoka/profiles`).
+- **Fixed:** the `Accept-Language` client-hint header is now derived from
+  `navigator.languages` (Chrome's q-value ordering) instead of hardcoded
+  `en-US,en;q=0.9` — geo-aligned identities no longer leak a header/JS
+  language mismatch.
+- Deleted dead code: unused `Fetch.continueRequest` / `Fetch.fulfillRequest` /
+  `Fetch.failRequest` / `Fetch.disable` session wrappers and their CDP types
+  (the transport auto-responder handles interception directly).
+
+### Fixed
+
+- **Timezone split-brain** (verified against stock Chrome): the JS shim made
+  `Intl` and `getTimezoneOffset()` claim the fingerprint timezone while
+  `Date.toString()`/`getHours()` still reported the host timezone — an
+  inconsistent pair any page can compare. Sessions now apply native
+  `Emulation.setTimezoneOverride` so the entire `Date`/`Intl` surface agrees.
+- **Impossible `prefers-reduced-motion` state**: the `matchMedia` wrapper
+  returned `matches: false` for both `reduce` and `no-preference` (one must
+  always match), and returned a non-`MediaQueryList` object. The wrapper is
+  removed; stock headless/new already reports the correct pair.
+- **`window.chrome` didn't match stock Chrome**: eoka injected a `runtime`
+  object that plain Chrome doesn't expose to pages (it's extension-only) and
+  is now verified against stock Chrome 152: keys are exactly
+  `["loadTimes", "csi", "app"]`.
+- **`navigator.deviceMemory` could report 16 or 32** — impossible values;
+  Chrome caps the report at 8. Buckets are now 4/8.
+- **macOS speech voices on non-macOS identities**: `speechSynthesis`
+  fallback voices are now platform-aware (macOS/Windows lists; Linux passes
+  through, matching stock Linux Chrome's zero voices).
+- **Cross-session linkable media devices**: fake `enumerateDevices`
+  group/device IDs were one eoka-wide constant; they are now derived from the
+  per-fingerprint noise seed.
+- **Canvas hook inconsistency**: `toDataURL`/`toBlob` were noised but plain
+  `getImageData` reads weren't, so a page comparing both could flag the
+  canvas. `getImageData` now applies the identical LSB noise.
+- `Intl.DateTimeFormat` no longer mutates the caller's options object.
+- **Profile directories were world-readable**: spawned profiles and CLI
+  profile clones (containing the cookie store) now get 0700 permissions.
+
+### Added
+
+- **Font identity**: `Fingerprint.fonts` — a platform-typical system font set
+  (Windows Segoe UI family, macOS Helvetica family, Linux DejaVu/Liberation
+  family, with per-identity variation on Linux). The new `document.fonts.check`
+  spoof resolves only claimed fonts plus CSS generic families, so font
+  enumeration reports the claimed OS instead of the host. Measurement-based
+  font probing (canvas `measureText`) is NOT covered.
+- **Keyboard layout**: `Fingerprint::keyboard_map_json()` — US ANSI
+  `KeyboardLayoutMap` for Windows/macOS identities (matching their en-US
+  locale); Linux passes through untouched (no fabrication where stock Chrome
+  exposes the real host layout).
+- **`StealthConfig.strip_x_client_data`** (default `true`). Chrome sends an
+  `X-Client-Data` request header with field-trial variation IDs to Google-owned
+  properties; a fresh automation profile has a distinctive (often empty) set
+  that server-side bot scoring reads before any JavaScript runs. Eoka now
+  launches Chrome with `--disable-field-trial-config` and strips the header
+  from every request via CDP `Fetch` interception (auto-continued in the
+  transport reader). Also fixes a latent transport bug: auto-responder CDP
+  command IDs above `i64::MAX` are silently dropped by DevTools, which would
+  have stalled any request paused by interception (and any `Fetch.authRequired`
+  flow).
+- **`StealthConfig.geo_align`** (default `false`). Resolves timezone and
+  `navigator.languages` from the browser's apparent public IP (ipwho.is, with a
+  Cloudflare-trace country fallback) via a one-shot navigation before the first
+  real page, keeping `Date`/`Intl`, `Accept-Language`, and the fingerprint
+  consistent with IP geolocation instead of a random timezone.
+
 ## [0.5.0] - 2026-07-06
 
 A refactor release: smaller, more reusable public API and a modern async

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,15 @@ Transport blocks detectable commands at `src/cdp/transport.rs:24-37`:
 - `HeapProfiler.*` - BLOCKED
 - `Console.enable` - BLOCKED
 
+### X-Client-Data Header
+Chromium sends `X-Client-Data` (field-trial variation IDs) on requests to
+Google-owned domains; a fresh automation profile has a distinctive set that
+Google scores before any page JS runs. Eoka launches with
+`--disable-field-trial-config` and strips the header via CDP Fetch
+interception auto-continued in the transport reader
+(`StealthConfig.strip_x_client_data`). Auto-responder CDP command IDs must
+stay within int32 — DevTools silently drops commands with larger ids.
+
 ### Document Proxy
 CDP markers ($cdc_*) are hidden via Proxy on document object. See `src/stealth/evasions.rs` CDP_EVASION.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eoka"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 rust-version = "1.74"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ let browser = Browser::launch_with(|config| {
 }).await?;
 ```
 
+Two server-side reputation signals are handled automatically for spawned
+stealth browsers (see `StealthConfig`):
+
+- `strip_x_client_data: true` (default) — Chrome's `X-Client-Data` request
+  header (field-trial variation IDs) is stripped via CDP Fetch interception on
+  every page, and `--disable-field-trial-config` is passed at launch.
+- `geo_align: false` — opt-in. Aligns timezone and `navigator.languages` with
+  the browser's apparent public IP via a one-shot lookup before the first real
+  navigation. Ignored when `timezone` is set explicitly.
+
 For reusable presets or advanced setup, build a `StealthConfig` directly:
 
 ```rust

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -6,11 +6,14 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::Value;
 
 /// Global counter for unique user data directories
 static BROWSER_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-use crate::cdp::transport::launch_chrome;
+use crate::cdp::transport::launch_chrome_with_profile_dir;
 use crate::cdp::types::{EmulationSetUserAgentOverride, UserAgentBrandVersion, UserAgentMetadata};
 use crate::cdp::{Connection, Transport};
 use crate::error::{Error, Result};
@@ -20,11 +23,43 @@ use crate::stealth::{build_evasion_script_for, find_chrome, ChromePatcher};
 use crate::StealthConfig;
 
 fn remove_dir_if_exists(path: &Path) -> std::io::Result<()> {
-    match std::fs::remove_dir_all(path) {
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        result => result,
+    const ATTEMPTS: usize = 10;
+
+    for attempt in 0..ATTEMPTS {
+        match std::fs::remove_dir_all(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) if is_directory_not_empty(&error) && attempt + 1 < ATTEMPTS => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(())
+}
+
+fn is_directory_not_empty(error: &std::io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(39) | Some(66) | Some(145))
+}
+
+/// Restrict a profile directory to its owner (0700). Profiles contain the
+/// cookie store; a default-umask /tmp directory would be world-readable.
+#[cfg(unix)]
+fn restrict_profile_perms(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o700);
+    if let Err(error) = std::fs::set_permissions(path, perms) {
+        tracing::warn!(
+            "Failed to restrict profile dir {}: {}",
+            path.display(),
+            error
+        );
     }
 }
+
+#[cfg(not(unix))]
+fn restrict_profile_perms(_path: &Path) {}
 
 async fn discover_browser_ws(port: u16) -> Result<String> {
     tokio::task::spawn_blocking(move || {
@@ -66,6 +101,10 @@ fn stealth_args(config: &StealthConfig, fingerprint: &Fingerprint) -> Vec<String
         "--password-store=basic".into(),
         "--use-mock-keychain".into(),
         "--lang=en-US".into(),
+        // Don't apply field-trial variations: they feed the `X-Client-Data`
+        // header Google properties use to profile installs (see
+        // `strip_x_client_data`).
+        "--disable-field-trial-config".into(),
         // Window size
         format!(
             "--window-size={},{}",
@@ -132,6 +171,7 @@ impl BrowserProfileGuard {
             Some(path) => {
                 let path = PathBuf::from(path);
                 std::fs::create_dir_all(&path)?;
+                restrict_profile_perms(&path);
                 Ok(Self { path, owned: false })
             }
             None => {
@@ -143,6 +183,7 @@ impl BrowserProfileGuard {
                 ));
                 remove_dir_if_exists(&path)?;
                 std::fs::create_dir_all(&path)?;
+                restrict_profile_perms(&path);
                 Ok(Self { path, owned: true })
             }
         }
@@ -313,7 +354,7 @@ fn prepare_browser_launch(config: Arc<StealthConfig>) -> Result<PreparedBrowserL
     args.push(format!("--user-data-dir={}", profile.path.display()));
 
     tracing::info!("Launching Chrome from {:?}", chrome_path);
-    let (child, ws_url) = launch_chrome(&chrome_path, &args)?;
+    let (child, ws_url) = launch_chrome_with_profile_dir(&chrome_path, &args, &profile.path)?;
     Ok(PreparedBrowserLaunch {
         child: Some(child),
         ws_url,
@@ -333,6 +374,103 @@ pub struct TabInfo {
     pub url: String,
 }
 
+/// One-shot navigation targets for geo alignment. The API returns JSON with
+/// `timezone.id` and `country_code`; the trace endpoint is a fallback that
+/// only yields the country (`loc=`).
+const GEO_API_URL: &str = "https://ipwho.is/";
+const GEO_TRACE_URL: &str = "https://www.cloudflare.com/cdn-cgi/trace";
+
+/// Geo info resolved from the browser's apparent public IP.
+#[derive(Debug, Clone)]
+struct GeoInfo {
+    timezone: Option<String>,
+    country: String,
+}
+
+/// Parse an ipwho.is response into [`GeoInfo`].
+fn parse_geo_api(text: &str) -> Option<GeoInfo> {
+    let value: Value = serde_json::from_str(text).ok()?;
+    let timezone = value.pointer("/timezone/id")?.as_str()?.to_string();
+    let country = value.get("country_code")?.as_str()?.to_string();
+    if timezone.is_empty()
+        || country.len() != 2
+        || !country.bytes().all(|byte| byte.is_ascii_alphabetic())
+    {
+        return None;
+    }
+    Some(GeoInfo {
+        timezone: Some(timezone),
+        country: country.to_uppercase(),
+    })
+}
+
+/// Parse a Cloudflare trace response into [`GeoInfo`] (country only — the
+/// trace response has no timezone field).
+fn parse_geo_trace(text: &str) -> Option<GeoInfo> {
+    let mut country = None;
+    for line in text.lines() {
+        if let Some(value) = line.strip_prefix("loc=") {
+            country = Some(value.trim().to_string());
+        }
+    }
+    let country = country.filter(|c| c.len() == 2 && c.chars().all(|c| c.is_ascii_alphabetic()))?;
+    Some(GeoInfo {
+        timezone: None,
+        country: country.to_uppercase(),
+    })
+}
+
+/// Browser `Accept-Language`-style list for an IP country code, matching how
+/// Chrome orders locales for a default install in that country.
+fn languages_for_country(country: &str) -> Vec<String> {
+    let languages: &[&str] = match country {
+        "US" => &["en-US", "en"],
+        "GB" => &["en-GB", "en"],
+        "AU" | "NZ" => &["en-AU", "en"],
+        "CA" => &["en-CA", "fr-CA", "en", "fr"],
+        "IE" => &["en-IE", "en"],
+        "IN" => &["en-IN", "hi-IN", "en", "hi"],
+        "DE" | "AT" => &["de-DE", "de"],
+        "CH" => &["de-CH", "fr-CH", "it-CH", "de", "fr", "it"],
+        "FR" | "LU" => &["fr-FR", "fr"],
+        "BE" => &["nl-BE", "fr-BE", "nl", "fr"],
+        "ES" | "MX" | "AR" | "CL" | "CO" => &["es-ES", "es"],
+        "BR" => &["pt-BR", "pt"],
+        "PT" => &["pt-PT", "pt"],
+        "IT" => &["it-IT", "it"],
+        "NL" => &["nl-NL", "nl"],
+        "SE" => &["sv-SE", "sv"],
+        "NO" => &["nb-NO", "no"],
+        "DK" => &["da-DK", "da"],
+        "FI" => &["fi-FI", "fi"],
+        "PL" => &["pl-PL", "pl"],
+        "CZ" | "SK" => &["cs-CZ", "cs"],
+        "HU" => &["hu-HU", "hu"],
+        "RO" => &["ro-RO", "ro"],
+        "GR" => &["el-GR", "el"],
+        "TR" => &["tr-TR", "tr"],
+        "RU" | "BY" | "KZ" => &["ru-RU", "ru"],
+        "UA" => &["uk-UA", "ru", "uk"],
+        "JP" => &["ja-JP", "ja"],
+        "KR" => &["ko-KR", "ko"],
+        "CN" => &["zh-CN", "zh"],
+        "TW" | "HK" => &["zh-TW", "zh"],
+        "VN" => &["vi-VN", "vi"],
+        "TH" => &["th-TH", "th"],
+        "ID" => &["id-ID", "id"],
+        "SA" | "AE" | "EG" => &["ar-SA", "ar"],
+        "IL" => &["he-IL", "he"],
+        _ => &["en-US", "en"],
+    };
+    languages.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// Navigate a page to `url` and return the body text (used for geo lookups).
+async fn read_remote_text(page: &Page, url: &str) -> Result<String> {
+    page.goto(url).await?;
+    page.text().await
+}
+
 /// Build the `Emulation.setUserAgentOverride` payload from the resolved fingerprint.
 fn ua_override_for(fp: &Fingerprint) -> EmulationSetUserAgentOverride {
     let to_brands = |v: Vec<(String, String)>| -> Vec<UserAgentBrandVersion> {
@@ -340,14 +478,12 @@ fn ua_override_for(fp: &Fingerprint) -> EmulationSetUserAgentOverride {
             .map(|(brand, version)| UserAgentBrandVersion { brand, version })
             .collect()
     };
-    let architecture = if fp.webgl_renderer.contains("Apple M") {
-        "arm"
-    } else {
-        "x86"
-    };
+    let architecture = fp.ch_architecture();
     EmulationSetUserAgentOverride {
         user_agent: fp.user_agent.clone(),
-        accept_language: Some("en-US,en;q=0.9".to_string()),
+        // Chrome sends the first language bare and the rest at q=0.9; the
+        // header must match `navigator.languages` (filled from the same list).
+        accept_language: Some(accept_language_for(&fp.languages)),
         platform: Some(fp.nav_platform().to_string()),
         user_agent_metadata: Some(UserAgentMetadata {
             brands: to_brands(fp.ch_brands()),
@@ -361,6 +497,21 @@ fn ua_override_for(fp: &Fingerprint) -> EmulationSetUserAgentOverride {
             wow64: false,
         }),
     }
+}
+
+/// Chrome-style `Accept-Language` value for a language list:
+/// `de-DE,de;q=0.9,en;q=0.8` — first entry bare, each following entry one
+/// quality step lower (minimum 0.1).
+fn accept_language_for(languages: &[String]) -> String {
+    languages
+        .iter()
+        .enumerate()
+        .map(|(index, language)| match index {
+            0 => language.clone(),
+            _ => format!("{};q={:.1}", language, (1.0 - 0.1 * index as f64).max(0.1)),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// The main stealth browser
@@ -423,14 +574,21 @@ impl Browser {
                     (Some(username), Some(password)) => Some((username.clone(), password.clone())),
                     _ => None,
                 };
-                Transport::new_with_options(child, &prepared.ws_url, proxy_auth, config.cdp_timeout)
-                    .await?
+                Transport::new_with_options(
+                    child,
+                    &prepared.ws_url,
+                    proxy_auth,
+                    config.cdp_timeout,
+                    config.strip_x_client_data,
+                )
+                .await?
             }
             None => {
                 Transport::connect_with_options(
                     &prepared.ws_url,
                     config.cdp_timeout,
                     config.filter_cdp,
+                    config.strip_x_client_data,
                 )
                 .await?
             }
@@ -451,14 +609,69 @@ impl Browser {
 
         let evasion_script = build_evasion_script_for(&config, &fingerprint);
 
-        Ok(Self {
+        let mut browser = Self {
             connection,
             config,
             user_data_dir,
             reused: !spawned,
             fingerprint: Some(fingerprint),
             evasion_script,
-        })
+        };
+        if spawned && browser.config.geo_align && browser.config.timezone.is_none() {
+            browser.align_geo().await;
+        }
+        Ok(browser)
+    }
+
+    /// Align timezone and interface languages with the browser's apparent
+    /// public IP via a one-shot navigation to Cloudflare's trace endpoint.
+    /// Runs before any real page exists, so every later page picks up the
+    /// aligned fingerprint in both the client-hint override and the evasion
+    /// script (`Date`, `Intl`, `navigator.languages`). Non-fatal on failure:
+    /// the random fingerprint timezone is kept and a warning is logged.
+    async fn align_geo(&mut self) {
+        let outcome: Result<GeoInfo> = async {
+            let page = self.new_blank_page().await?;
+            let result: Result<GeoInfo> = async {
+                match read_remote_text(&page, GEO_API_URL)
+                    .await
+                    .ok()
+                    .and_then(|ref text| parse_geo_api(text))
+                {
+                    Some(geo) => Ok(geo),
+                    None => {
+                        let text = read_remote_text(&page, GEO_TRACE_URL).await?;
+                        parse_geo_trace(&text)
+                            .ok_or_else(|| Error::Launch("geo response missing loc".into()))
+                    }
+                }
+            }
+            .await;
+            let _ = self.close_tab(page.target_id()).await;
+            result
+        }
+        .await;
+
+        match outcome {
+            Ok(geo) => {
+                if let Some(fp) = self.fingerprint.as_mut() {
+                    if let Some(timezone) = geo.timezone {
+                        fp.timezone = timezone;
+                    }
+                    fp.languages = languages_for_country(&geo.country);
+                }
+                if let Some(fp) = self.fingerprint.as_ref() {
+                    self.evasion_script = build_evasion_script_for(&self.config, fp);
+                }
+                tracing::info!(
+                    "Geo-aligned languages/timezone (IP country {})",
+                    geo.country
+                );
+            }
+            Err(error) => {
+                tracing::warn!("Geo alignment failed, keeping random timezone: {}", error);
+            }
+        }
     }
 
     /// Connect to an existing Chrome instance at the given WebSocket CDP URL.
@@ -479,6 +692,7 @@ impl Browser {
             ws_url,
             config.cdp_timeout,
             config.filter_cdp,
+            config.strip_x_client_data && !config.live_session,
         )
         .await?;
         let connection = Connection::new(transport);
@@ -522,8 +736,12 @@ impl Browser {
     async fn setup_session(&self, session: &crate::cdp::Session) -> Result<()> {
         session.page_enable().await?;
 
-        if self.config.proxy_username.is_some() && self.config.proxy_password.is_some() {
-            session.fetch_enable(true).await?;
+        let proxy_auth =
+            self.config.proxy_username.is_some() && self.config.proxy_password.is_some();
+        if proxy_auth || self.config.strip_x_client_data {
+            session
+                .fetch_enable_interception(vec![], proxy_auth)
+                .await?;
         }
 
         if self.config.ignore_cert_errors {
@@ -533,6 +751,12 @@ impl Browser {
         if !self.config.live_session {
             if let Some(ref fp) = self.fingerprint {
                 session.set_user_agent_full(ua_override_for(fp)).await?;
+                // Native ICU override: makes `Date.toString()`, `getHours()` and
+                // friends consistent with the claimed timezone (a JS shim alone
+                // leaves them reporting the host timezone).
+                if let Err(error) = session.set_timezone_override(&fp.timezone).await {
+                    tracing::warn!("Timezone override failed for {}: {}", fp.timezone, error);
+                }
             }
             session
                 .add_script_to_evaluate_on_new_document(&self.evasion_script)
@@ -765,5 +989,127 @@ mod try_attach_existing_tests {
             error
         );
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn parses_geo_api_response() {
+        let body = r#"{"ip":"203.0.113.9","country_code":"DE","timezone":{"id":"Europe/Berlin","abbr":"CEST"}}"#;
+        let geo = parse_geo_api(body).expect("valid geo api response");
+        assert_eq!(geo.timezone.as_deref(), Some("Europe/Berlin"));
+        assert_eq!(geo.country, "DE");
+        assert!(parse_geo_api("not json").is_none());
+        assert!(parse_geo_api(r#"{"success":false,"message":"rate limited"}"#).is_none());
+    }
+
+    #[test]
+    fn parses_geo_trace_response() {
+        let trace = "fl=123\n\nip=203.0.113.9\nloc=DE\nsnf=oia\n";
+        let geo = parse_geo_trace(trace).expect("valid trace");
+        assert_eq!(geo.timezone, None);
+        assert_eq!(geo.country, "DE");
+    }
+
+    #[test]
+    fn rejects_malformed_geo_trace() {
+        assert!(parse_geo_trace("fl=1\nip=1.2.3.4\n").is_none());
+        assert!(parse_geo_trace("loc=\n").is_none());
+        assert!(parse_geo_trace("loc=DEU\n").is_none());
+        assert!(parse_geo_trace("").is_none());
+    }
+
+    #[test]
+    fn languages_match_ip_country() {
+        assert_eq!(languages_for_country("DE"), vec!["de-DE", "de"]);
+        assert_eq!(languages_for_country("JP"), vec!["ja-JP", "ja"]);
+        assert_eq!(
+            languages_for_country("CA"),
+            vec!["en-CA", "fr-CA", "en", "fr"]
+        );
+        assert_eq!(languages_for_country("ZZ"), vec!["en-US", "en"]);
+    }
+
+    #[test]
+    fn stealth_args_disable_field_trials() {
+        let config = StealthConfig::default();
+        let fp = Fingerprint::random();
+        let args = stealth_args(&config, &fp);
+        assert!(args.iter().any(|arg| arg == "--disable-field-trial-config"));
+    }
+
+    // Privacy regression: profile dirs hold the cookie store and previously
+    // landed in /tmp with default umask (world-readable). They must be 0700.
+    #[cfg(unix)]
+    #[test]
+    fn profile_dirs_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let owned = BrowserProfileGuard::create(&StealthConfig::default()).unwrap();
+        let mode = std::fs::metadata(&owned.path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "spawned temp profile dir must be 0700");
+        std::fs::remove_dir_all(&owned.path).unwrap();
+
+        let custom = temp_profile_dir("user-supplied");
+        let guard = BrowserProfileGuard::create(&StealthConfig {
+            user_data_dir: Some(custom.to_string_lossy().into_owned()),
+            ..StealthConfig::default()
+        })
+        .unwrap();
+        let mode = std::fs::metadata(&guard.path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "user-supplied profile dir must be tightened to 0700"
+        );
+        std::fs::remove_dir_all(&custom).unwrap();
+    }
+
+    // Audit regression: the Accept-Language header used to be hardcoded
+    // en-US while navigator.languages followed the fingerprint/geo align —
+    // a header-vs-JS mismatch any server can compare.
+    #[test]
+    fn accept_language_matches_fingerprint_languages() {
+        assert_eq!(
+            accept_language_for(&["en-US".into(), "en".into()]),
+            "en-US,en;q=0.9"
+        );
+        assert_eq!(
+            accept_language_for(&["de-DE".into(), "de".into(), "en".into()]),
+            "de-DE,de;q=0.9,en;q=0.8"
+        );
+
+        let fp = Fingerprint::random();
+        let override_payload = ua_override_for(&fp);
+        assert_eq!(
+            override_payload.accept_language.as_deref(),
+            Some(accept_language_for(&fp.languages).as_str()),
+            "Accept-Language must be derived from navigator.languages"
+        );
+    }
+
+    // Regression: the fonts and keyboard hooks must be present and driven by
+    // fingerprint data, with Linux keyboard passing through untouched.
+    #[test]
+    fn fonts_and_keyboard_hooks_are_fingerprint_driven() {
+        let windows_fp = Fingerprint::resolve(
+            Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7312.86 Safari/537.36"),
+            None,
+        );
+        let windows_script = build_evasion_script_for(&StealthConfig::default(), &windows_fp);
+        assert!(windows_script.contains("document.fonts.check"));
+        assert!(
+            windows_script.contains(&serde_json::to_string(&windows_fp.fonts).unwrap()),
+            "claimed font set must flow into the script"
+        );
+        assert!(windows_script.contains("getLayoutMap"));
+
+        let linux_fp = Fingerprint::resolve(
+            Some("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7312.86 Safari/537.36"),
+            None,
+        );
+        let linux_script = build_evasion_script_for(&StealthConfig::default(), &linux_fp);
+        assert!(
+            linux_script
+                .contains("if (navigator.keyboard && navigator.keyboard.getLayoutMap && null)"),
+            "Linux keyboard spoof must be inert"
+        );
     }
 }

--- a/src/cdp/connection.rs
+++ b/src/cdp/connection.rs
@@ -171,11 +171,6 @@ impl Session {
 
     /// Enable the Fetch domain, optionally handling auth challenges (proxy auth).
     /// Must be called per-session (per-tab).
-    pub(crate) async fn fetch_enable(&self, handle_auth_requests: bool) -> Result<()> {
-        self.fetch_enable_interception(vec![], handle_auth_requests)
-            .await
-    }
-
     /// Enable page events
     pub(crate) async fn page_enable(&self) -> Result<()> {
         self.send_void("Page.enable", &PageEnable {}).await
@@ -275,6 +270,17 @@ impl Session {
             .await
     }
 
+    /// Set the browser-native ICU timezone for this session.
+    pub(crate) async fn set_timezone_override(&self, timezone_id: &str) -> Result<()> {
+        self.send_void(
+            "Emulation.setTimezoneOverride",
+            &EmulationSetTimezoneOverride {
+                timezone_id: timezone_id.to_string(),
+            },
+        )
+        .await
+    }
+
     /// Ignore TLS certificate errors for this session.
     pub(crate) async fn set_ignore_cert_errors(&self, ignore: bool) -> Result<()> {
         self.send_void(
@@ -317,77 +323,6 @@ impl Session {
                     Some(patterns)
                 },
                 handle_auth_requests: Some(handle_auth),
-            },
-        )
-        .await
-    }
-
-    /// Disable Fetch domain interception.
-    #[allow(dead_code)] // request-interception wrapper, kept for completeness
-    pub(crate) async fn fetch_disable(&self) -> Result<()> {
-        self.send_void("Fetch.disable", &FetchDisable {}).await
-    }
-
-    /// Continue an intercepted request, optionally modifying URL/method/headers/body.
-    #[allow(dead_code)] // request-interception wrapper, kept for completeness
-    pub(crate) async fn fetch_continue(
-        &self,
-        request_id: &str,
-        url: Option<&str>,
-        method: Option<&str>,
-        headers: Option<Vec<FetchHeaderEntry>>,
-        post_data: Option<&str>,
-    ) -> Result<()> {
-        self.send_void(
-            "Fetch.continueRequest",
-            &FetchContinueRequest {
-                request_id: request_id.to_string(),
-                url: url.map(String::from),
-                method: method.map(String::from),
-                post_data: post_data.map(String::from),
-                headers,
-                intercept_response: None,
-            },
-        )
-        .await
-    }
-
-    /// Fulfill an intercepted request with a synthetic response.
-    /// `body` will be base64-encoded automatically.
-    #[allow(dead_code)] // request-interception wrapper, kept for completeness
-    pub(crate) async fn fetch_fulfill(
-        &self,
-        request_id: &str,
-        status_code: u16,
-        headers: Option<Vec<FetchHeaderEntry>>,
-        body: Option<&str>,
-    ) -> Result<()> {
-        let encoded_body = body.map(|b| {
-            use base64::Engine;
-            base64::engine::general_purpose::STANDARD.encode(b)
-        });
-        self.send_void(
-            "Fetch.fulfillRequest",
-            &FetchFulfillRequest {
-                request_id: request_id.to_string(),
-                response_code: status_code,
-                response_headers: headers,
-                body: encoded_body,
-                response_phrase: None,
-            },
-        )
-        .await
-    }
-
-    /// Abort an intercepted request with a network error.
-    /// `error_reason`: "Aborted", "AccessDenied", "AddressUnreachable", "ConnectionRefused", etc.
-    #[allow(dead_code)] // request-interception wrapper, kept for completeness
-    pub(crate) async fn fetch_fail(&self, request_id: &str, error_reason: &str) -> Result<()> {
-        self.send_void(
-            "Fetch.failRequest",
-            &FetchFailRequest {
-                request_id: request_id.to_string(),
-                error_reason: error_reason.to_string(),
             },
         )
         .await

--- a/src/cdp/transport.rs
+++ b/src/cdp/transport.rs
@@ -5,9 +5,11 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader};
+use std::path::Path;
 use std::process::{Child, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -108,6 +110,23 @@ impl Drop for ChildCleanupGuard {
 /// Broadcast capacity for CDP events (multi-consumer, lag observable).
 const EVENT_CHANNEL_CAP: usize = 1024;
 
+/// Remove `X-Client-Data` from a CDP request-headers object (case-insensitive
+/// match, like HTTP header semantics). Returns `None` when the header is
+/// absent so callers can continue the request unmodified.
+fn strip_client_data_header(headers: &Value) -> Option<serde_json::Map<String, Value>> {
+    let map = headers.as_object()?;
+    let has_header = map.keys().any(|k| k.eq_ignore_ascii_case("x-client-data"));
+    if !has_header {
+        return None;
+    }
+    Some(
+        map.iter()
+            .filter(|(k, _)| !k.eq_ignore_ascii_case("x-client-data"))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    )
+}
+
 /// Check if a command should be blocked (highly detectable by anti-bot)
 fn is_blocked(method: &str) -> bool {
     matches!(
@@ -184,7 +203,7 @@ pub enum CdpMessage {
 impl Transport {
     /// Create a new transport connecting to Chrome via WebSocket
     pub async fn new(child: Child, ws_url: &str) -> Result<Self> {
-        Self::new_with_options(child, ws_url, None, 30).await
+        Self::new_with_options(child, ws_url, None, 30, false).await
     }
 
     /// Connect the WebSocket and return the stream.
@@ -209,6 +228,7 @@ impl Transport {
         proxy_auth: Option<(String, String)>,
         cdp_timeout_secs: u64,
         filter_cdp: bool,
+        strip_x_client_data: bool,
     ) -> Self {
         let cmd_timeout = std::time::Duration::from_secs(cdp_timeout_secs);
         tracing::debug!("CDP timeout set to {}s", cdp_timeout_secs);
@@ -229,6 +249,7 @@ impl Transport {
                 event_tx_clone,
                 reader_writer,
                 proxy_auth,
+                strip_x_client_data,
             )
             .await;
         });
@@ -246,12 +267,14 @@ impl Transport {
         }
     }
 
-    /// Create a new transport with proxy auth and configurable CDP timeout.
+    /// Create a new transport with proxy auth, X-Client-Data stripping and
+    /// configurable CDP timeout.
     pub async fn new_with_options(
         child: Child,
         ws_url: &str,
         proxy_auth: Option<(String, String)>,
         cdp_timeout_secs: u64,
+        strip_x_client_data: bool,
     ) -> Result<Self> {
         let mut child = ChildCleanupGuard::new(child);
         let stream = Self::ws_connect(ws_url).await?;
@@ -261,6 +284,7 @@ impl Transport {
             proxy_auth,
             cdp_timeout_secs,
             true,
+            strip_x_client_data,
         ))
     }
 
@@ -268,7 +292,14 @@ impl Transport {
     /// Does not manage a Chrome process — caller owns the browser lifecycle.
     pub async fn connect(ws_url: &str, cdp_timeout_secs: u64) -> Result<Self> {
         let stream = Self::ws_connect(ws_url).await?;
-        Ok(Self::build(None, stream, None, cdp_timeout_secs, true))
+        Ok(Self::build(
+            None,
+            stream,
+            None,
+            cdp_timeout_secs,
+            true,
+            false,
+        ))
     }
 
     /// Connect to an existing Chrome with full options control. Use
@@ -278,6 +309,7 @@ impl Transport {
         ws_url: &str,
         cdp_timeout_secs: u64,
         filter_cdp: bool,
+        strip_x_client_data: bool,
     ) -> Result<Self> {
         let stream = Self::ws_connect(ws_url).await?;
         Ok(Self::build(
@@ -286,23 +318,32 @@ impl Transport {
             None,
             cdp_timeout_secs,
             filter_cdp,
+            strip_x_client_data,
         ))
     }
 
     /// Reader task — reads CDP messages off the WebSocket. tokio-tungstenite
     /// handles framing/fragmentation/close; we only reply to pings and parse
     /// text payloads. If `proxy_auth` is set, `Fetch.authRequired` events are
-    /// auto-answered with `Fetch.continueWithAuth`.
+    /// auto-answered with `Fetch.continueWithAuth`. When Fetch interception is
+    /// active (proxy auth or X-Client-Data stripping), `Fetch.requestPaused`
+    /// events are always auto-continued — interception pauses every matching
+    /// request, so an unanswered pause would hang the page forever. With
+    /// `strip_x_client_data` the `X-Client-Data` header is removed on the way
+    /// through.
     async fn reader_loop(
         mut source: WsSource,
         pending: Arc<PendingMap>,
         event_tx: broadcast::Sender<CdpMessage>,
         writer: SharedSink,
         proxy_auth: Option<(String, String)>,
+        strip_x_client_data: bool,
     ) {
         let exit_reason;
-        // Separate command ID space for auth responses (won't collide with main IDs)
-        let mut auth_cmd_id: u64 = u64::MAX / 2;
+        // Separate command ID space for auth/interception auto-responses (won't
+        // collide with main IDs for the first ~2 billion commands). Must stay
+        // within int32: DevTools silently drops commands with ids outside it.
+        let mut auth_cmd_id: u64 = 1_000_000_000;
 
         loop {
             let text = match source.next().await {
@@ -416,6 +457,50 @@ impl Transport {
                             continue; // Don't forward to event channel
                         }
                     }
+                }
+
+                // Auto-continue paused requests when Fetch interception is
+                // active (proxy auth or X-Client-Data stripping). Interception
+                // pauses every matching request; an unanswered pause would
+                // hang the page forever.
+                if method == "Fetch.requestPaused" {
+                    if let Some(request_id) = params.get("requestId").and_then(|v| v.as_str()) {
+                        let request_headers = params
+                            .pointer("/request/headers")
+                            .cloned()
+                            .unwrap_or(json!({}));
+                        let modified_headers = if strip_x_client_data {
+                            strip_client_data_header(&request_headers)
+                        } else {
+                            None
+                        };
+                        auth_cmd_id += 1;
+                        let mut response = json!({
+                            "id": auth_cmd_id,
+                            "method": "Fetch.continueRequest",
+                            "params": {
+                                "requestId": request_id,
+                            }
+                        });
+                        if let Some(headers) = modified_headers {
+                            response["params"]["headers"] = Value::Object(headers);
+                        }
+                        if let Some(ref sid) = session_id {
+                            response["sessionId"] = json!(sid);
+                        }
+                        if let Ok(data) = serde_json::to_string(&response) {
+                            let mut w = writer.lock().await;
+                            if let Err(e) = w.send(Message::Text(data.into())).await {
+                                exit_reason = format!("Fetch continue write failed: {}", e);
+                                // Break so pending requests fail immediately
+                                // instead of hanging.
+                                break;
+                            } else {
+                                tracing::trace!("Auto-continued paused request");
+                            }
+                        }
+                    }
+                    continue; // Don't forward to event channel
                 }
 
                 // Publish event; ignore "no active receivers" errors.
@@ -630,6 +715,22 @@ impl Drop for Transport {
 
 /// Launch Chrome and get the WebSocket debugging URL
 pub fn launch_chrome(path: &std::path::Path, args: &[String]) -> Result<(Child, String)> {
+    launch_chrome_impl(path, args, None)
+}
+
+pub(crate) fn launch_chrome_with_profile_dir(
+    path: &std::path::Path,
+    args: &[String],
+    profile_dir: &Path,
+) -> Result<(Child, String)> {
+    launch_chrome_impl(path, args, Some(profile_dir))
+}
+
+fn launch_chrome_impl(
+    path: &std::path::Path,
+    args: &[String],
+    profile_dir: Option<&Path>,
+) -> Result<(Child, String)> {
     use std::process::Command;
 
     let mut cmd = Command::new(path);
@@ -643,7 +744,6 @@ pub fn launch_chrome(path: &std::path::Path, args: &[String]) -> Result<(Child, 
         .spawn()
         .map_err(|e| Error::Launch(format!("Failed to launch Chrome: {}", e)))?;
 
-    // Read stderr to find the DevTools URL (with 30s timeout)
     let stderr = child
         .stderr
         .take()
@@ -652,44 +752,164 @@ pub fn launch_chrome(path: &std::path::Path, args: &[String]) -> Result<(Child, 
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
-        // Chrome prints: DevTools listening on ws://127.0.0.1:PORT/devtools/browser/GUID
+        let mut stderr_tail = Vec::new();
         for line in reader.lines() {
             let line = match line {
                 Ok(l) => l,
-                Err(_) => break,
+                Err(error) => {
+                    let _ = tx.send(Err(format!("failed to read Chrome stderr: {}", error)));
+                    return;
+                }
             };
 
             tracing::trace!("Chrome stderr: {}", line);
+            stderr_tail.push(line.clone());
+            if stderr_tail.len() > 20 {
+                stderr_tail.remove(0);
+            }
 
             if line.contains("DevTools listening on") {
                 if let Some(url_start) = line.find("ws://") {
-                    if tx.send(line[url_start..].trim().to_string()).is_err() {
+                    if tx.send(Ok(line[url_start..].trim().to_string())).is_err() {
                         tracing::debug!("Chrome launch receiver dropped before URL delivery");
                     }
                     return;
                 }
             }
         }
+        let stderr = stderr_tail.join("\n");
+        let message = if stderr.is_empty() {
+            "Chrome exited before printing DevTools URL and produced no stderr".to_string()
+        } else {
+            format!(
+                "Chrome exited before printing DevTools URL. stderr:\n{}",
+                stderr
+            )
+        };
+        let _ = tx.send(Err(message));
     });
 
-    let ws_url = match rx.recv_timeout(std::time::Duration::from_secs(30)) {
-        Ok(url) => url,
-        Err(channel_error) => {
-            // Kill Chrome so a missing DevTools URL can't orphan it.
-            if let Err(cleanup_error) = stop_child(&mut child) {
-                tracing::warn!(
-                    "Failed to clean up Chrome after launch-channel error: {}",
-                    cleanup_error
-                );
-            }
-            return Err(Error::Launch(format!(
-                "Failed waiting for Chrome DevTools URL: {}",
-                channel_error
-            )));
-        }
-    };
+    let ws_url = wait_for_chrome_devtools_url(&mut child, &rx, profile_dir)?;
 
     tracing::info!("Chrome DevTools URL: {}", ws_url);
 
     Ok((child, ws_url))
+}
+
+fn wait_for_chrome_devtools_url(
+    child: &mut Child,
+    rx: &std::sync::mpsc::Receiver<std::result::Result<String, String>>,
+    profile_dir: Option<&Path>,
+) -> Result<String> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+
+    loop {
+        match rx.try_recv() {
+            Ok(Ok(url)) => return Ok(url),
+            Ok(Err(stderr)) => {
+                let status = child
+                    .try_wait()
+                    .map(|status| status.map(|s| s.to_string()))
+                    .unwrap_or(None)
+                    .unwrap_or_else(|| "still running".to_string());
+                stop_child_after_failed_launch(child);
+                return Err(Error::Launch(format!(
+                    "Failed waiting for Chrome DevTools URL: process {}; {}",
+                    status, stderr
+                )));
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                stop_child_after_failed_launch(child);
+                return Err(Error::Launch(
+                    "Failed waiting for Chrome DevTools URL: stderr reader exited unexpectedly"
+                        .into(),
+                ));
+            }
+        }
+
+        if let Some(dir) = profile_dir {
+            if let Some(port) = crate::cdp::discover::read_devtools_active_port(dir) {
+                return crate::cdp::discover::discover_browser_ws("127.0.0.1", port).map_err(
+                    |error| {
+                        Error::Launch(format!(
+                            "Chrome wrote DevToolsActivePort ({}) but discovery failed: {}",
+                            port, error
+                        ))
+                    },
+                );
+            }
+        }
+
+        if let Ok(Some(status)) = child.try_wait() {
+            let stderr = rx
+                .recv_timeout(Duration::from_millis(250))
+                .ok()
+                .and_then(|result| result.err())
+                .unwrap_or_else(|| "Chrome exited before printing DevTools URL".to_string());
+            stop_child_after_failed_launch(child);
+            return Err(Error::Launch(format!(
+                "Failed waiting for Chrome DevTools URL: process {}; {}",
+                status, stderr
+            )));
+        }
+
+        if Instant::now() >= deadline {
+            stop_child_after_failed_launch(child);
+            return Err(Error::Launch(
+                "Failed waiting for Chrome DevTools URL after 30s".into(),
+            ));
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn stop_child_after_failed_launch(child: &mut Child) {
+    if let Err(cleanup_error) = stop_child(child) {
+        tracing::warn!(
+            "Failed to clean up Chrome after launch-channel error: {}",
+            cleanup_error
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_x_client_data_case_insensitively() {
+        let headers = json!({
+            "User-Agent": "test",
+            "X-Client-Data": "abc123",
+            "Accept": "*/*"
+        });
+        let stripped = strip_client_data_header(&headers).expect("header present");
+        assert_eq!(stripped.len(), 2);
+        assert!(stripped.get("User-Agent").is_some());
+        assert!(stripped.get("Accept").is_some());
+        assert!(strip_client_data_header(&Value::Object(stripped)).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_header_absent() {
+        let headers = json!({ "User-Agent": "test", "Accept": "*/*" });
+        assert!(strip_client_data_header(&headers).is_none());
+        assert!(strip_client_data_header(&json!({})).is_none());
+        assert!(strip_client_data_header(&json!(null)).is_none());
+    }
+
+    #[test]
+    fn preserves_other_headers_verbatim() {
+        let headers = json!({
+            "sec-ch-ua": "\"Chromium\";v=\"140\"",
+            "x-client-data": "CJKxyz="
+        });
+        let stripped = strip_client_data_header(&headers).expect("header present");
+        assert_eq!(
+            stripped.get("sec-ch-ua").and_then(|v| v.as_str()),
+            Some("\"Chromium\";v=\"140\"")
+        );
+    }
 }

--- a/src/cdp/types.rs
+++ b/src/cdp/types.rs
@@ -795,6 +795,15 @@ pub struct SecuritySetIgnoreCertificateErrors {
     pub ignore: bool,
 }
 
+/// Emulation.setTimezoneOverride — set the browser-native ICU timezone for
+/// this session. Unlike a JS shim, this makes `Date.toString()`, `getHours()`,
+/// `Intl` and friends natively consistent with the claimed timezone.
+#[derive(Debug, Clone, Serialize)]
+pub struct EmulationSetTimezoneOverride {
+    #[serde(rename = "timezoneId")]
+    pub timezone_id: String,
+}
+
 /// Page.handleJavaScriptDialog — accept or dismiss an open JS dialog
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -827,58 +836,6 @@ pub struct FetchEnable {
     pub patterns: Option<Vec<RequestPattern>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub handle_auth_requests: Option<bool>,
-}
-
-/// Fetch.disable — turn off Fetch domain interception
-pub type FetchDisable = Empty;
-
-/// A single header name/value pair used in Fetch.fulfillRequest / Fetch.continueRequest
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FetchHeaderEntry {
-    pub name: String,
-    pub value: String,
-}
-
-/// Fetch.continueRequest — pass an intercepted request through (optionally modified)
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FetchContinueRequest {
-    pub request_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub method: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub post_data: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<Vec<FetchHeaderEntry>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub intercept_response: Option<bool>,
-}
-
-/// Fetch.fulfillRequest — respond to an intercepted request with a synthetic response
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FetchFulfillRequest {
-    pub request_id: String,
-    pub response_code: u16,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_headers: Option<Vec<FetchHeaderEntry>>,
-    /// base64-encoded body
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_phrase: Option<String>,
-}
-
-/// Fetch.failRequest — abort an intercepted request with a network error
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FetchFailRequest {
-    pub request_id: String,
-    /// CDP NetworkErrorReason, e.g. "Aborted", "AccessDenied", "AddressUnreachable"
-    pub error_reason: String,
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,21 @@ pub struct StealthConfig {
     /// certs (e.g. .onion services) hit on the very first load. Defaults to
     /// false.
     pub ignore_cert_errors: bool,
+    /// Strip Chromium's `X-Client-Data` request header via CDP Fetch
+    /// interception. Chrome sends this header with field-trial variation IDs on
+    /// requests to Google-owned properties; a fresh automation profile carries
+    /// a distinctive (often empty) variation set that server-side bot scoring
+    /// can read before any JavaScript runs. Also launches Chrome with
+    /// `--disable-field-trial-config`. Defaults to true for spawned stealth
+    /// browsers; ignored (never applied) for attached live sessions.
+    pub strip_x_client_data: bool,
+    /// Resolve timezone and interface language from the browser's apparent
+    /// public IP via a one-shot navigation to Cloudflare's trace endpoint
+    /// before any real page is created. Keeps `Date`/`Intl` and the injected
+    /// `navigator.languages` consistent with IP geolocation instead of a
+    /// random timezone. Ignored when `timezone` is set explicitly and when
+    /// attaching to an existing browser. Defaults to false.
+    pub geo_align: bool,
 }
 
 impl Default for StealthConfig {
@@ -200,6 +215,8 @@ impl Default for StealthConfig {
             live_session: false,
             filter_cdp: true,
             ignore_cert_errors: false,
+            strip_x_client_data: true,
+            geo_align: false,
         }
     }
 }

--- a/src/stealth/evasions.rs
+++ b/src/stealth/evasions.rs
@@ -4,7 +4,7 @@
 //! detectable browser properties.
 
 use crate::page::escape_js_string;
-use crate::stealth::fingerprint::Fingerprint;
+use crate::stealth::fingerprint::{Fingerprint, GENERIC_FONTS};
 use crate::StealthConfig;
 
 /// Native-function masking: makes `_eoka_mark`ed functions report native code from `.toString()`.
@@ -222,28 +222,11 @@ if (document.documentElement) {
 document.addEventListener('DOMContentLoaded', cleanupDocAttributes);
 "#;
 
-/// Chrome runtime object
+/// Chrome runtime object. Matches a real, extension-less Chrome page context:
+/// `Object.keys(window.chrome)` is `["loadTimes", "csi", "app"]` and
+/// `chrome.runtime` is undefined (verified against stock Chrome 152).
 pub const CHROME_RUNTIME_EVASION: &str = r#"
 window.chrome = {
-    runtime: {
-        onConnect: {
-            addListener: function() {},
-            removeListener: function() {}
-        },
-        onMessage: {
-            addListener: function() {},
-            removeListener: function() {}
-        },
-        connect: function() {
-            return {
-                onMessage: { addListener: function() {} },
-                onDisconnect: { addListener: function() {} },
-                postMessage: function() {}
-            };
-        },
-        sendMessage: function() {},
-        id: undefined
-    },
     loadTimes: function() {
         return {
             commitLoadTime: Date.now() / 1000 - _eoka_rand() * 2,
@@ -399,34 +382,18 @@ for (const [prop, desc] of Object.entries(navProps)) {
 
 /// Headless detection bypass
 pub const HEADLESS_EVASION: &str = r#"
-// Fix screen properties
+// Fix screen properties. The subtracted band is the OS chrome height
+// (taskbar / menu bar) claimed by the fingerprint.
 Object.defineProperty(screen, 'availWidth', { get: _eoka_mark(() => screen.width, 'get availWidth'), configurable: true });
-Object.defineProperty(screen, 'availHeight', { get: _eoka_mark(() => screen.height - 40, 'get availHeight'), configurable: true });
+Object.defineProperty(screen, 'availHeight', { get: _eoka_mark(() => screen.height - __EOKA_UI_CHROME__, 'get availHeight'), configurable: true });
 
 // Mock window dimensions
 Object.defineProperty(window, 'outerWidth', { get: _eoka_mark(() => window.innerWidth, 'get outerWidth'), configurable: true });
 Object.defineProperty(window, 'outerHeight', { get: _eoka_mark(() => window.innerHeight + 85, 'get outerHeight'), configurable: true });
 
-// Fix window.matchMedia
-const originalMatchMedia = window.matchMedia;
-if (originalMatchMedia) {
-    window.matchMedia = _eoka_mark(function matchMedia(query) {
-        const result = originalMatchMedia.call(window, query);
-        if (query.includes('prefers-reduced-motion')) {
-            return {
-                matches: false,
-                media: query,
-                onchange: null,
-                addListener: function() {},
-                removeListener: function() {},
-                addEventListener: function() {},
-                removeEventListener: function() {},
-                dispatchEvent: function() { return true; }
-            };
-        }
-        return result;
-    }, 'matchMedia');
-}
+// Real headless/new and headed Chrome both report the native pair
+// (reduce=false, no-preference=true). Wrapping matchMedia used to fabricate
+// an impossible both-false state, so it is intentionally left untouched.
 
 // Ensure window.origin is correct
 try {
@@ -555,6 +522,20 @@ if (origToBlob) {
     }, 'toBlob');
 }
 
+// getImageData must see the same LSB noise as toDataURL/toBlob, otherwise a
+// page comparing the pixel buffer against the data URL catches the hook.
+const origGetImageData = CanvasRenderingContext2D.prototype.getImageData;
+CanvasRenderingContext2D.prototype.getImageData = _eoka_mark(function getImageData(...args) {
+    const img = origGetImageData.apply(this, args);
+    const data = img.data;
+    let s = (__EOKA_NOISE_SEED__ >>> 0) || 1;
+    for (let i = 0; i < data.length; i += 4) {
+        s = _eoka_lcg(s);
+        data[i] = data[i] ^ (s & 1);
+    }
+    return img;
+}, 'getImageData');
+
 // Audio noise — deterministic, applied once per channel buffer.
 const origGetChannelData = AudioBuffer.prototype.getChannelData;
 const _eoka_audioSeen = new WeakSet();
@@ -604,16 +585,12 @@ if (typeof webkitRTCPeerConnection !== 'undefined') {
 }
 "#;
 
-/// Speech synthesis - headless Chrome has 0 voices, real Chrome has many
+/// Speech synthesis - headless Chrome has 0 voices, real Chrome has many.
+/// The fallback list is fingerprint data (`__EOKA_SPEECH_VOICES__`, JSON):
+/// platform-aware and stable per identity.
 pub const SPEECH_EVASION: &str = r#"
 if (typeof speechSynthesis !== 'undefined') {
-    const defaultVoices = [
-        { name: 'Alex', lang: 'en-US', localService: true, default: true, voiceURI: 'Alex' },
-        { name: 'Samantha', lang: 'en-US', localService: true, default: false, voiceURI: 'Samantha' },
-        { name: 'Victoria', lang: 'en-US', localService: true, default: false, voiceURI: 'Victoria' },
-        { name: 'Daniel', lang: 'en-GB', localService: true, default: false, voiceURI: 'Daniel' },
-        { name: 'Google US English', lang: 'en-US', localService: false, default: false, voiceURI: 'Google US English' }
-    ].map(v => {
+    const defaultVoices = __EOKA_SPEECH_VOICES__.map(v => {
         const voice = Object.create(SpeechSynthesisVoice.prototype);
         Object.defineProperties(voice, {
             name: { value: v.name, enumerable: true },
@@ -633,20 +610,18 @@ if (typeof speechSynthesis !== 'undefined') {
 }
 "#;
 
-/// Media devices - headless returns empty array
+/// Media devices - headless returns empty array. The fake device list is
+/// fingerprint data (`__EOKA_MEDIA_DEVICES__`, JSON) derived from the noise
+/// seed, so IDs are stable per identity and never shared across sessions.
 pub const MEDIA_DEVICES_EVASION: &str = r#"
 if (navigator.mediaDevices && navigator.mediaDevices.enumerateDevices) {
     const origEnumerateDevices = navigator.mediaDevices.enumerateDevices.bind(navigator.mediaDevices);
 
+    const fakeDevices = __EOKA_MEDIA_DEVICES__;
     navigator.mediaDevices.enumerateDevices = _eoka_mark(async function enumerateDevices() {
         const devices = await origEnumerateDevices();
         if (devices.length === 0) {
-            const fake = [
-                { deviceId: 'default', groupId: '5f8b2c1e9a3d', kind: 'audioinput', label: '' },
-                { deviceId: 'default', groupId: '5f8b2c1e9a3d', kind: 'audiooutput', label: '' },
-                { deviceId: 'e2d4a6c8b0f1', groupId: '9c3e7a1d4b6f', kind: 'videoinput', label: '' }
-            ];
-            return fake.map(d => {
+            return fakeDevices.map(d => {
                 const device = Object.create(MediaDeviceInfo.prototype);
                 Object.defineProperties(device, {
                     deviceId: { value: d.deviceId, enumerable: true },
@@ -681,6 +656,55 @@ if (!navigator.bluetooth) {
 }
 "#;
 
+/// System-font probing via `document.fonts.check(font, text)`: stock Chrome
+/// resolves installed system fonts, so detectors enumerate font names through
+/// it. Only the identity's claimed fonts (plus CSS generic families) resolve;
+/// everything else reports missing. The claimed set is fingerprint data
+/// (`__EOKA_FONTS__`, JSON array).
+pub const FONTS_EVASION: &str = r#"
+if (document.fonts && document.fonts.check) {
+    const origCheck = document.fonts.check.bind(document.fonts);
+    const claimedFonts = new Set(__EOKA_FONTS__.map(f => f.toLowerCase()));
+    const genericFonts = new Set(__EOKA_GENERIC_FONTS__);
+    const familyAllowed = (family) =>
+        claimedFonts.has(family.toLowerCase()) || genericFonts.has(family.toLowerCase());
+
+    document.fonts.check = _eoka_mark(function check(font, text) {
+        if (typeof font !== 'string' || font === '') return origCheck(font, text);
+        const sizeMatch = font.match(/(?:\d+(?:\.\d+)?(?:px|pt|em|rem|ex|ch|vh|vw|%)|[xx]-?small|medium|[xx]-?large)\s*(.*)$/i);
+        const familyList = sizeMatch ? sizeMatch[1] : font;
+        if (!familyList.trim()) return origCheck(font, text);
+        const families = familyList.split(',').map(f => f.trim().replace(/^['"]|['"]$/g, ''));
+        if (!families.length || families.some(f => !f)) return origCheck(font, text);
+        return families.every(familyAllowed);
+    }, 'check');
+}
+"#;
+
+/// `navigator.keyboard.getLayoutMap()` — stock Chrome exposes the Keyboard
+/// API on Windows/macOS/ChromeOS but not Linux, so Linux passes through.
+/// The map is fingerprint data (`__EOKA_KEYBOARD_MAP__`, JSON or null):
+/// US ANSI, matching the identity's en-US locale.
+pub const KEYBOARD_EVASION: &str = r#"
+if (navigator.keyboard && navigator.keyboard.getLayoutMap && __EOKA_KEYBOARD_MAP__) {
+    const layoutEntries = __EOKA_KEYBOARD_MAP__;
+    const layoutMap = new Map(Object.entries(layoutEntries));
+    const fakeMap = {
+        get: _eoka_mark((code) => layoutMap.get(code) || null, 'get'),
+        has: _eoka_mark((code) => layoutMap.has(code), 'has'),
+        size: layoutMap.size,
+        entries: _eoka_mark(() => layoutMap.entries(), 'entries'),
+        forEach: _eoka_mark((cb, thisArg) => layoutMap.forEach(cb, thisArg), 'forEach'),
+        [Symbol.iterator]: _eoka_mark(function* () {
+            yield* layoutMap.entries();
+        }, '[Symbol.iterator]'),
+    };
+    navigator.keyboard.getLayoutMap = _eoka_mark(function getLayoutMap() {
+        return Promise.resolve(fakeMap);
+    }, 'getLayoutMap');
+}
+"#;
+
 /// Timezone consistency - ensure Date timezone matches claimed location.
 /// The `__EOKA_TIMEZONE__` placeholder is replaced at build time with the
 /// actual IANA timezone from StealthConfig.
@@ -690,9 +714,9 @@ const targetTimezone = '__EOKA_TIMEZONE__';
 const origDateTimeFormat = Intl.DateTimeFormat;
 
 Intl.DateTimeFormat = _eoka_mark(function DateTimeFormat(locales, options) {
-    if (!options) options = {};
-    if (!options.timeZone) options.timeZone = targetTimezone;
-    return new origDateTimeFormat(locales, options);
+    const merged = options ? Object.assign({}, options) : {};
+    if (!merged.timeZone) merged.timeZone = targetTimezone;
+    return new origDateTimeFormat(locales, merged);
 }, 'DateTimeFormat');
 Intl.DateTimeFormat.prototype = origDateTimeFormat.prototype;
 Intl.DateTimeFormat.supportedLocalesOf = origDateTimeFormat.supportedLocalesOf;
@@ -768,6 +792,8 @@ pub fn build_evasion_script_for(config: &StealthConfig, fp: &Fingerprint) -> Str
         WEBRTC_EVASION,
         SPEECH_EVASION,
         MEDIA_DEVICES_EVASION,
+        FONTS_EVASION,
+        KEYBOARD_EVASION,
         BLUETOOTH_EVASION,
         TIMEZONE_EVASION,
     ];
@@ -795,19 +821,44 @@ pub fn build_evasion_script_for(config: &StealthConfig, fp: &Fingerprint) -> Str
     let noise_seed = fp.noise_seed;
 
     let script = format!("(function(){{{}}})();", scripts.join("\n"));
-    script
-        .replace("__EOKA_TIMEZONE__", &escape_js_string(&timezone))
-        .replace("__EOKA_PLATFORM__", &escape_js_string(fp.nav_platform()))
-        .replace("__EOKA_LANGUAGES__", &languages_json)
-        .replace("__EOKA_LANGUAGE__", &escape_js_string(&language))
-        .replace("__EOKA_HW__", &fp.hardware_concurrency.to_string())
-        .replace("__EOKA_MEM__", &fp.device_memory.to_string())
-        .replace("__EOKA_WEBGL_VENDOR__", &escape_js_string(&fp.webgl_vendor))
-        .replace(
+
+    // Single fill-point: every placeholder value comes from the fingerprint
+    // (or config). No placeholder may survive this fold — guarded by
+    // `test_placeholders_are_filled`.
+    let placeholders: Vec<(&str, String)> = vec![
+        ("__EOKA_TIMEZONE__", escape_js_string(&timezone)),
+        ("__EOKA_PLATFORM__", escape_js_string(fp.nav_platform())),
+        ("__EOKA_LANGUAGES__", languages_json),
+        ("__EOKA_LANGUAGE__", escape_js_string(&language)),
+        ("__EOKA_HW__", fp.hardware_concurrency.to_string()),
+        ("__EOKA_MEM__", fp.device_memory.to_string()),
+        ("__EOKA_WEBGL_VENDOR__", escape_js_string(&fp.webgl_vendor)),
+        (
             "__EOKA_WEBGL_RENDERER__",
-            &escape_js_string(&fp.webgl_renderer),
-        )
-        .replace("__EOKA_NOISE_SEED__", &noise_seed.to_string())
+            escape_js_string(&fp.webgl_renderer),
+        ),
+        ("__EOKA_NOISE_SEED__", noise_seed.to_string()),
+        (
+            "__EOKA_SPEECH_VOICES__",
+            serde_json::to_string(&fp.voices).unwrap_or_else(|_| "[]".to_string()),
+        ),
+        ("__EOKA_MEDIA_DEVICES__", fp.media_devices_json()),
+        ("__EOKA_UI_CHROME__", fp.ui_chrome_height().to_string()),
+        (
+            "__EOKA_FONTS__",
+            serde_json::to_string(&fp.fonts).unwrap_or_else(|_| "[]".to_string()),
+        ),
+        (
+            "__EOKA_GENERIC_FONTS__",
+            serde_json::to_string(GENERIC_FONTS).unwrap_or_else(|_| "[]".to_string()),
+        ),
+        ("__EOKA_KEYBOARD_MAP__", fp.keyboard_map_json()),
+    ];
+    placeholders
+        .into_iter()
+        .fold(script, |acc, (placeholder, value)| {
+            acc.replace(placeholder, &value)
+        })
 }
 
 /// Build the complete evasion script based on config.
@@ -928,6 +979,182 @@ mod tests {
         assert!(
             !script.contains("'Foo'Bar'"),
             "unescaped single quote must not appear"
+        );
+    }
+
+    // Audit regression: stock Chrome pages expose window.chrome keys as
+    // ["loadTimes", "csi", "app"] only — chrome.runtime is extension-only and
+    // must never be injected (verified against stock Chrome 152).
+    #[test]
+    fn test_chrome_object_matches_stock() {
+        let script = build_evasion_script(&StealthConfig::default());
+        assert!(
+            script.contains("loadTimes: function"),
+            "chrome.loadTimes must be spoofed (present in stock Chrome)"
+        );
+        assert!(
+            script.contains("csi: function"),
+            "chrome.csi must be spoofed (present in stock Chrome)"
+        );
+        assert!(
+            !script.contains("onConnect"),
+            "chrome.runtime stub must not be re-added: plain pages have no runtime"
+        );
+        assert!(
+            !script.contains("sendMessage: function"),
+            "chrome.runtime stub must not be re-added"
+        );
+    }
+
+    // Audit regression: the old matchMedia wrapper reported matches:false for
+    // BOTH prefers-reduced-motion variants — an impossible state (one always
+    // matches in real Chrome) — and returned a non-MediaQueryList object.
+    #[test]
+    fn test_match_media_is_not_wrapped() {
+        let script = build_evasion_script(&StealthConfig::default());
+        assert!(
+            !script.contains("originalMatchMedia"),
+            "matchMedia must not be wrapped: stock headless/new reports the correct pair"
+        );
+    }
+
+    // Audit regression: fallback voices must match the claimed platform.
+    // Alex/Samantha are macOS-only; Microsoft David/Zira are Windows-only;
+    // stock Linux Chrome has no built-in voices (pass-through).
+    #[test]
+    fn test_speech_voices_match_platform() {
+        let voices_for = |ua: &str| {
+            let fp = Fingerprint::resolve(Some(ua), None);
+            let script = build_evasion_script_for(&StealthConfig::default(), &fp);
+            let start = script
+                .find("const defaultVoices = ")
+                .expect("voices array present")
+                + "const defaultVoices = ".len();
+            let end = script[start..]
+                .find(".map(v =>")
+                .expect("voices array terminated");
+            script[start..start + end].trim().to_string()
+        };
+
+        let linux = voices_for("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36");
+        assert_eq!(
+            linux, "[]",
+            "Linux identities must pass through with no voices"
+        );
+
+        let mac = voices_for("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36");
+        let mac_json: serde_json::Value =
+            serde_json::from_str(&mac).expect("macOS voices must be valid JSON");
+        let mac_names: Vec<&str> = mac_json
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["name"].as_str().unwrap())
+            .collect();
+        assert!(mac_names.contains(&"Alex"), "macOS list must contain Alex");
+        assert!(!mac_names.iter().any(|n| n.starts_with("Microsoft")));
+
+        let win = voices_for("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36");
+        let win_json: serde_json::Value =
+            serde_json::from_str(&win).expect("Windows voices must be valid JSON");
+        let win_names: Vec<&str> = win_json
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            win_names.iter().any(|n| n.starts_with("Microsoft David")),
+            "Windows list must contain Microsoft David"
+        );
+        assert!(!win_names.contains(&"Alex"), "Alex is macOS-only");
+    }
+
+    // Audit regression: fake media-device IDs used to be one hardcoded
+    // constant shared by every eoka session, linking all identities. They are
+    // now fingerprint data (spec + noise seed), stable per identity and
+    // distinct across identities.
+    #[test]
+    fn test_media_device_ids_are_seeded_per_fingerprint() {
+        let devices_json = |script: &str| -> serde_json::Value {
+            let start = script
+                .find("const fakeDevices = ")
+                .expect("fake device list present")
+                + "const fakeDevices = ".len();
+            let end = script[start..].find(';').expect("device list terminated");
+            serde_json::from_str(&script[start..start + end])
+                .expect("media device list must be valid JSON")
+        };
+
+        let script = build_evasion_script(&StealthConfig::default());
+        assert!(
+            !script.contains("5f8b2c1e9a3d"),
+            "hardcoded cross-session groupId must not reappear"
+        );
+
+        let devices = devices_json(&script).as_array().cloned().unwrap();
+        assert!(!devices.is_empty());
+        let mut ids: Vec<&str> = devices
+            .iter()
+            .map(|d| d["deviceId"].as_str().unwrap())
+            .collect();
+        let defaults = ids.iter().filter(|id| **id == "default").count();
+        ids.retain(|id| *id != "default");
+        assert_eq!(
+            ids.len(),
+            ids.iter().collect::<std::collections::HashSet<_>>().len(),
+            "non-default device IDs must be unique within an identity"
+        );
+        assert!(
+            ids.iter().all(|id| id.len() == 12),
+            "device IDs must be 12 hex chars like real enumerated IDs"
+        );
+        assert!(defaults >= 2, "audio in/out pair should include 'default'");
+
+        // Different fingerprints must present different hardware IDs. The
+        // identity (and therefore the seed) is randomized per build.
+        let fps_a = Fingerprint::random();
+        let fps_b = Fingerprint::random();
+        let ids_a =
+            devices_json(&build_evasion_script_for(&StealthConfig::default(), &fps_a)).to_string();
+        let ids_b =
+            devices_json(&build_evasion_script_for(&StealthConfig::default(), &fps_b)).to_string();
+        assert_ne!(
+            ids_a, ids_b,
+            "distinct identities must not share device IDs (linkability)"
+        );
+    }
+
+    // Audit regression: canvas reads through getImageData must carry the same
+    // noise as toDataURL/toBlob, or a page comparing both flags the hook.
+    #[test]
+    fn test_get_image_data_is_noised_with_canvas_spoof() {
+        let on = build_evasion_script(&StealthConfig::default());
+        assert!(
+            on.contains("CanvasRenderingContext2D.prototype.getImageData"),
+            "getImageData must be hooked when canvas spoofing is on"
+        );
+
+        let off = build_evasion_script(&StealthConfig {
+            webgl_spoof: false,
+            canvas_spoof: false,
+            audio_spoof: false,
+            ..StealthConfig::default()
+        });
+        assert!(
+            !off.contains("getImageData"),
+            "canvas hooks must be absent when all fingerprint spoofs are off"
+        );
+    }
+
+    // Audit regression: the Intl shim must not mutate the caller's options
+    // object (observable side effect).
+    #[test]
+    fn test_intl_shim_clones_options() {
+        let script = build_evasion_script(&StealthConfig::default());
+        assert!(
+            script.contains("Object.assign({}, options)"),
+            "Intl.DateTimeFormat shim must clone options before injecting timeZone"
         );
     }
 }

--- a/src/stealth/fingerprint.rs
+++ b/src/stealth/fingerprint.rs
@@ -11,6 +11,7 @@ use std::io;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 const PERSISTED_FINGERPRINT_FILE: &str = ".eoka-fingerprint.json";
 
@@ -88,6 +89,210 @@ fn choose<T>(slice: &[T]) -> &T {
     &slice[fastrand::usize(..slice.len())]
 }
 
+/// A system text-to-speech voice as reported by `speechSynthesis.getVoices()`.
+/// Field names serialize exactly as the Web Speech API spells them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeechVoice {
+    /// Voice display name, e.g. "Alex".
+    pub name: String,
+    /// BCP-47 language tag, e.g. "en-US".
+    pub lang: String,
+    /// Whether the voice is available offline.
+    pub local_service: bool,
+    /// Whether this is the platform default voice.
+    pub default: bool,
+    /// Voice identifier (same as `name` for system voices).
+    #[serde(rename = "voiceURI")]
+    pub voice_uri: String,
+}
+
+/// Typical audio/video hardware for one identity, as produced by a fake
+/// `mediaDevices.enumerateDevices()` when the real list is empty.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MediaDevicesSpec {
+    /// Microphone count.
+    pub audio_inputs: u32,
+    /// Speaker/output count.
+    pub audio_outputs: u32,
+    /// Camera count.
+    pub video_inputs: u32,
+}
+
+impl Default for MediaDevicesSpec {
+    fn default() -> Self {
+        Self {
+            audio_inputs: 1,
+            audio_outputs: 1,
+            video_inputs: 1,
+        }
+    }
+}
+
+impl MediaDevicesSpec {
+    /// Plausible hardware for a claimed platform. Windows/macOS identities
+    /// look like laptops (webcam present); Linux desktops frequently have
+    /// none.
+    fn for_platform(platform: Platform) -> Self {
+        match platform {
+            Platform::Linux => Self {
+                video_inputs: *choose(&[0, 0, 1]),
+                ..Self::default()
+            },
+            _ => Self {
+                audio_inputs: 1,
+                audio_outputs: *choose(&[1, 2]),
+                video_inputs: 1,
+            },
+        }
+    }
+}
+
+/// Platform-typical fallback voices for `speechSynthesis.getVoices()`. Stock
+/// Linux Chrome has none (empty list = pass-through); Alex/Samantha are
+/// macOS-only, David/Zira are Windows-only.
+fn default_voices_for(platform: Platform) -> Vec<SpeechVoice> {
+    let voices: &[(&str, &str, bool, bool)] = match platform {
+        Platform::MacOS => &[
+            ("Alex", "en-US", true, true),
+            ("Samantha", "en-US", true, false),
+            ("Victoria", "en-US", true, false),
+            ("Daniel", "en-GB", true, false),
+            ("Google US English", "en-US", false, false),
+        ],
+        Platform::Windows => &[
+            (
+                "Microsoft David - English (United States)",
+                "en-US",
+                true,
+                true,
+            ),
+            (
+                "Microsoft Zira - English (United States)",
+                "en-US",
+                true,
+                false,
+            ),
+            (
+                "Microsoft Mark - English (United States)",
+                "en-US",
+                true,
+                false,
+            ),
+            ("Google US English", "en-US", false, false),
+        ],
+        Platform::Linux => &[],
+    };
+    voices
+        .iter()
+        .map(|(name, lang, local, default)| SpeechVoice {
+            name: (*name).to_string(),
+            lang: (*lang).to_string(),
+            local_service: *local,
+            default: *default,
+            voice_uri: (*name).to_string(),
+        })
+        .collect()
+}
+
+/// Base system font set for a claimed platform, as seen by
+/// `document.fonts.check` probing. Order-insensitive; generics are always
+/// allowed on top of these.
+fn base_fonts_for(platform: Platform) -> &'static [&'static str] {
+    match platform {
+        Platform::Windows => &[
+            "Segoe UI",
+            "Arial",
+            "Calibri",
+            "Cambria",
+            "Consolas",
+            "Courier New",
+            "Georgia",
+            "Impact",
+            "Tahoma",
+            "Times New Roman",
+            "Trebuchet MS",
+            "Verdana",
+            "Microsoft Sans Serif",
+            "Comic Sans MS",
+            "Candara",
+            "Franklin Gothic Medium",
+            "Rockwell",
+        ],
+        Platform::MacOS => &[
+            "Helvetica",
+            "Helvetica Neue",
+            "Arial",
+            "Menlo",
+            "Monaco",
+            "Courier New",
+            "Georgia",
+            "Times New Roman",
+            "Palatino",
+            "Avenir",
+            "Avenir Next",
+            "Futura",
+            "Geneva",
+            "Lucida Grande",
+            "Optima",
+            "Baskerville",
+            "American Typewriter",
+        ],
+        Platform::Linux => &[
+            "DejaVu Sans",
+            "DejaVu Serif",
+            "DejaVu Sans Mono",
+            "Liberation Sans",
+            "Liberation Serif",
+            "Liberation Mono",
+            "Ubuntu",
+            "Cantarell",
+            "FreeSans",
+            "FreeSerif",
+            "Noto Sans",
+            "Noto Serif",
+            "Noto Mono",
+        ],
+    }
+}
+
+/// Font families every real Chrome resolves regardless of installed fonts.
+pub(crate) const GENERIC_FONTS: &[&str] = &[
+    "serif",
+    "sans-serif",
+    "monospace",
+    "cursive",
+    "fantasy",
+    "system-ui",
+    "ui-sans-serif",
+    "ui-serif",
+    "ui-monospace",
+    "ui-rounded",
+    "math",
+    "emoji",
+    "none",
+];
+
+/// US ANSI layout: `KeyboardLayoutMap.get(code)` entries for the punctuation
+/// and space keys. Letters and digits are generated programmatically.
+const US_LAYOUT_ENTRIES: &[(&str, &str)] = &[
+    ("Backquote", "`"),
+    ("Minus", "-"),
+    ("Equal", "="),
+    ("BracketLeft", "["),
+    ("BracketRight", "]"),
+    ("Backslash", "\\"),
+    ("Semicolon", ";"),
+    ("Quote", "'"),
+    ("Comma", ","),
+    ("Period", "."),
+    ("Slash", "/"),
+    ("Space", " "),
+];
+
+/// Build the US-layout letter and digit entries programmatically is not
+/// possible in a const table, so `keyboard_map_json` appends KeyA-KeyZ and
+/// Digit0-Digit9 at runtime.
 /// WebGL vendor, WebGL renderer and client-hint platform version for a platform.
 fn platform_surfaces(platform: Platform) -> (&'static str, String, String) {
     match platform {
@@ -175,6 +380,16 @@ pub struct Fingerprint {
     /// Stable canvas/audio perturbation seed for this identity.
     #[serde(default = "random_noise_seed")]
     pub noise_seed: u32,
+    /// Platform-typical fallback for `speechSynthesis.getVoices()` when the
+    /// real list is empty (empty for Linux: stock Linux Chrome has none).
+    pub voices: Vec<SpeechVoice>,
+    /// Fake `mediaDevices.enumerateDevices()` hardware counts when the real
+    /// list is empty.
+    pub media_devices: MediaDevicesSpec,
+    /// System fonts claimed installed for this identity (drives the
+    /// `document.fonts.check` spoof). Generic families are always allowed on
+    /// top of this set.
+    pub fonts: Vec<String>,
 }
 
 /// Operating system platform for a fingerprint.
@@ -219,12 +434,31 @@ impl Fingerprint {
             screen_height,
             color_depth: 24,
             hardware_concurrency: *choose(&[4, 8, 10, 12, 16]),
-            device_memory: *choose(&[8, 8, 16, 32]),
+            // Chrome reports deviceMemory capped at 8 (spec: one of
+            // 0.25..8); 16/32 are impossible values and an instant tell.
+            device_memory: *choose(&[4, 8, 8]),
             timezone: choose(super::evasions::COMMON_TIMEZONES).to_string(),
             languages: vec!["en-US".to_string(), "en".to_string()],
             webgl_vendor: webgl_vendor.to_string(),
             webgl_renderer,
             noise_seed: random_noise_seed(),
+            voices: default_voices_for(platform),
+            media_devices: MediaDevicesSpec::for_platform(platform),
+            fonts: {
+                let mut fonts: Vec<String> = base_fonts_for(platform)
+                    .iter()
+                    .map(|f| (*f).to_string())
+                    .collect();
+                // Linux font sets differ the most between machines; rotate and
+                // trim a random tail so identities don't all look identical.
+                if platform == Platform::Linux {
+                    let rotate = fastrand::usize(..fonts.len());
+                    fonts.rotate_left(rotate);
+                    let drop = choose(&[1usize, 1, 2, 3]);
+                    fonts.truncate(fonts.len() - drop);
+                }
+                fonts
+            },
         }
     }
 
@@ -337,6 +571,90 @@ impl Fingerprint {
         }
     }
 
+    /// Client-hint `architecture` for the claimed platform. `platform_surfaces`
+    /// picks Apple-silicon renderers for macOS, so macOS claims are ARM.
+    pub fn ch_architecture(&self) -> &'static str {
+        match self.platform {
+            Platform::MacOS => "arm",
+            Platform::Windows | Platform::Linux => "x86",
+        }
+    }
+
+    /// Assumed OS chrome (taskbar/menu bar) height subtracted from
+    /// `screen.height` when spoofing `screen.availHeight`.
+    pub fn ui_chrome_height(&self) -> u32 {
+        match self.platform {
+            Platform::MacOS => 25,
+            Platform::Windows => 40,
+            Platform::Linux => 30,
+        }
+    }
+
+    /// JSON `KeyboardLayoutMap` entries for the claimed platform, or `null`
+    /// where the Keyboard API doesn't exist in stock Chrome (Linux). All
+    /// eoka identities use en-US locales, so the layout is US ANSI.
+    pub fn keyboard_map_json(&self) -> String {
+        match self.platform {
+            Platform::Linux => "null".to_string(),
+            Platform::Windows | Platform::MacOS => {
+                let mut map = serde_json::Map::new();
+                for (code, key) in US_LAYOUT_ENTRIES {
+                    map.insert((*code).to_string(), json!((*key).to_string()));
+                }
+                for letter in b'a'..=b'z' {
+                    let key = (letter as char).to_string();
+                    map.insert(format!("Key{}", key.to_ascii_uppercase()), json!(key));
+                }
+                for digit in 0..10u8 {
+                    map.insert(format!("Digit{digit}"), json!(digit.to_string()));
+                }
+                serde_json::to_string(&map).unwrap_or_else(|_| "null".to_string())
+            }
+        }
+    }
+
+    /// JSON device list for the `mediaDevices.enumerateDevices` fallback,
+    /// built from the spec and noise seed so IDs are stable per identity.
+    pub fn media_devices_json(&self) -> String {
+        let mut seed = self.noise_seed as u64 ^ 0x9e37_79b9_7f4a_7c15;
+        let mut device_id = move || {
+            let mut id = String::with_capacity(12);
+            for _ in 0..12 {
+                seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+                id.push(char::from_digit(((seed >> 28) & 0xf) as u32, 16).unwrap_or('0'));
+            }
+            id
+        };
+
+        let mut devices: Vec<serde_json::Value> = Vec::new();
+        let audio_group = device_id();
+        for index in 0..self.media_devices.audio_inputs {
+            devices.push(json!({
+                "deviceId": if index == 0 { "default".into() } else { device_id() },
+                "groupId": audio_group,
+                "kind": "audioinput",
+                "label": "",
+            }));
+        }
+        for index in 0..self.media_devices.audio_outputs {
+            devices.push(json!({
+                "deviceId": if index == 0 { "default".into() } else { device_id() },
+                "groupId": audio_group,
+                "kind": "audiooutput",
+                "label": "",
+            }));
+        }
+        for index in 0..self.media_devices.video_inputs {
+            devices.push(json!({
+                "deviceId": if index == 0 { "default".into() } else { device_id() },
+                "groupId": device_id(),
+                "kind": "videoinput",
+                "label": "",
+            }));
+        }
+        serde_json::to_string(&devices).unwrap_or_else(|_| "[]".to_string())
+    }
+
     /// `Sec-CH-UA-Platform` value ("macOS" / "Windows").
     pub fn ch_platform(&self) -> &'static str {
         match self.platform {
@@ -414,13 +732,29 @@ mod tests {
     }
 
     #[test]
+    fn test_device_memory_never_exceeds_chrome_cap() {
+        // Regression: 16/32 are impossible values — Chrome's spec buckets end
+        // at 8, and an out-of-range report is an instant bot tell.
+        for _ in 0..200 {
+            let fp = Fingerprint::random();
+            assert!(
+                fp.device_memory <= 8,
+                "device_memory {} exceeds Chrome's cap of 8",
+                fp.device_memory
+            );
+            assert!([0.25_f64, 0.5, 1.0, 2.0, 4.0, 8.0].contains(&(fp.device_memory as f64)));
+        }
+    }
+
+    #[test]
     fn test_fingerprint_random_is_consistent() {
         for _ in 0..50 {
             let fp = Fingerprint::random();
             assert!(!fp.user_agent.is_empty());
             assert!(fp.screen_width > 0 && fp.screen_height > 0);
             assert!([4, 8, 10, 12, 16].contains(&fp.hardware_concurrency));
-            assert!([8, 16, 32].contains(&fp.device_memory));
+            // Chrome caps the reported value at 8 (spec bucket maximum).
+            assert!([4, 8].contains(&fp.device_memory));
             match fp.platform {
                 Platform::MacOS => {
                     assert!(fp.user_agent.contains("Macintosh"));
@@ -451,6 +785,94 @@ mod tests {
         assert_eq!(fp.platform, Platform::Windows);
         assert_eq!(fp.chrome_major, "140");
         assert_eq!(fp.nav_platform(), "Win32");
+    }
+
+    // Coherence matrix: whatever the claimed platform, every platform-derived
+    // surface must agree — architecture, OS chrome height, voices, devices,
+    // fonts, keyboard.
+    #[test]
+    fn test_platform_surfaces_are_coherent() {
+        let cases = [
+            (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7312.86 Safari/537.36",
+                "x86",
+                40,
+                "Microsoft David",
+                "Segoe UI",
+            ),
+            (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7312.86 Safari/537.36",
+                "arm",
+                25,
+                "Alex",
+                "Helvetica",
+            ),
+            (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7312.86 Safari/537.36",
+                "x86",
+                30,
+                "",
+                "DejaVu",
+            ),
+        ];
+        for (ua, architecture, chrome_height, expected_voice, expected_font_prefix) in cases {
+            let fp = Fingerprint::resolve(Some(ua), None);
+            assert_eq!(fp.ch_architecture(), architecture);
+            assert_eq!(fp.ui_chrome_height(), chrome_height);
+
+            if expected_voice.is_empty() {
+                assert!(fp.voices.is_empty(), "Linux claims must have no voices");
+            } else {
+                assert!(
+                    fp.voices.iter().any(|v| v.name.starts_with(expected_voice)),
+                    "voices must match the claimed platform (expected {expected_voice})"
+                );
+            }
+
+            // Fonts: the representative platform font must be claimed, and no
+            // other platform's signature font may appear.
+            assert!(
+                fp.fonts.iter().any(|f| f.starts_with(expected_font_prefix)),
+                "fonts must match the claimed platform (expected {expected_font_prefix})"
+            );
+            let disallowed: &[&str] = match expected_font_prefix {
+                "Segoe UI" => &["Helvetica Neue", "Cantarell", "DejaVu Sans"],
+                "Helvetica" => &["Segoe UI", "Cantarell", "DejaVu Sans"],
+                _ => &["Segoe UI", "Helvetica Neue"],
+            };
+            for other_font in disallowed {
+                assert!(
+                    !fp.fonts.iter().any(|f| f.starts_with(other_font)),
+                    "cross-platform font {other_font} must not be claimed here"
+                );
+            }
+
+            // Keyboard: Linux has no Keyboard API in stock Chrome; Win/macOS
+            // get a complete US layout.
+            let keyboard = fp.keyboard_map_json();
+            if expected_voice.is_empty() {
+                assert_eq!(keyboard, "null");
+            } else {
+                let map: serde_json::Map<String, serde_json::Value> =
+                    serde_json::from_str(&keyboard).expect("keyboard map must be valid JSON");
+                assert_eq!(map.get("KeyA").and_then(|v| v.as_str()), Some("a"));
+                assert_eq!(map.get("Digit1").and_then(|v| v.as_str()), Some("1"));
+                assert_eq!(map.get("Minus").and_then(|v| v.as_str()), Some("-"));
+                assert_eq!(map.len(), 26 + 10 + 12);
+            }
+
+            let devices: serde_json::Value =
+                serde_json::from_str(&fp.media_devices_json()).expect("valid device JSON");
+            let array = devices.as_array().unwrap();
+            let expected_len = (fp.media_devices.audio_inputs
+                + fp.media_devices.audio_outputs
+                + fp.media_devices.video_inputs) as usize;
+            assert_eq!(array.len(), expected_len);
+            for device in array {
+                assert_eq!(device["label"], "");
+                assert!(device["kind"].is_string());
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Why
The Google /sorry investigation showed eoka getting flagged at request time, before any page JS ran. Server-side signals were the gap: the `X-Client-Data` header (field-trial variation IDs), random timezones inconsistent with the IP, and a hardcoded `Accept-Language`.

## Changes
- **X-Client-Data stripping** (`strip_x_client_data`, default on): `--disable-field-trial-config` + CDP Fetch interception auto-continued in the transport reader
- **Transport fix**: auto-responder CDP ids exceeded DevTools' int32 range and were silently dropped — any paused request hung (also broke proxy auth)
- **Native timezone override** (`Emulation.setTimezoneOverride`): `Date.toString()`/`getHours()` now agree with `Intl` (the JS shim left them on host tz)
- **Geo alignment** (`geo_align`, opt-in): timezone + languages from the apparent public IP (ipwho.is, Cloudflare trace country fallback) before the first real page
- **Accept-Language** derived from `navigator.languages` with Chrome's q-value ordering
- **Platform-owned identity on `Fingerprint`**: speech voices, media-device spec, system font set (`document.fonts.check` spoof), US keyboard layout (`getLayoutMap` spoof), per-OS chrome bar height — evasions are now placeholder templates with a single fill-point
- **Audit fixes**: impossible prefers-reduced-motion pair, injected `chrome.runtime` absent from stock Chrome, `deviceMemory` > 8, `getImageData` missing canvas noise, cross-session linkable media-device ids, Intl options mutation
- **Privacy**: profile directories 0700 (cookie store was world-readable in /tmp)
- Removed dead Fetch wrappers and their CDP types

## Breaking
Persisted identities missing the new fields fail strictly — old durable profiles must be deleted.

## Verification
121 lib tests (fmt/clippy clean); live-verified against stock Chrome 152 ground truth; sannysoft/BrowserLeaks/CreepJS re-run.